### PR TITLE
Added VaryingCDF, a general parameter dependant CDF. Also added Print

### DIFF
--- a/examples/VaryingCDF.cpp
+++ b/examples/VaryingCDF.cpp
@@ -1,0 +1,179 @@
+#include <string>        
+#include <vector>        
+#include <math.h>	
+#include <fstream>
+
+#include <Rand.h>
+#include <Exceptions.h>
+#include <Convolution.h>
+#include <Gaussian.h>
+#include <ParameterDict.h>
+#include <ContainerTools.hpp>
+#include <SparseMatrix.h>
+#include <DistTools.h>
+
+#include <VaryingCDF.h>
+#include <ContainerParameter.h>
+#include <Formatter.hpp>
+#include <Function.h>
+#include <Gaussian.h>
+
+#include <TH1D.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+#include <TStyle.h>
+
+#include <set>
+#include <map>
+#include <vector>
+
+using ContainerTools::ToString;
+using ContainerTools::GetValues;
+using ContainerTools::GetKeys;
+
+//Quick function ploy(x) = a*sqrt(abs(x)) + b
+class Ploy : public Function{
+    public:
+        // Constructory things
+        Ploy(const std::string& name_,const double grad, const double offset){
+            fName=name_;
+            parameters["grad"]=grad;
+            parameters["offset"]=offset;
+        }
+
+        Ploy(const Ploy& copy_){
+            fName=copy_.fName;
+            parameters=copy_.parameters;
+        }
+
+
+        Ploy& operator=(const Ploy& copy_){
+            fName=copy_.fName;
+            parameters=copy_.parameters;
+            return *this;
+        }
+
+        // Probability
+        double operator()(const std::vector<double>& vals_) const{
+            return parameters.at("grad")*sqrt(abs(vals_[0]))+parameters.at("offset");
+        }
+
+        int GetNDims() const{
+            return 1;
+        }
+
+        Function* Clone() const{
+            return static_cast<Function*> (new Ploy(*this));
+        }
+
+        void SetParameter(const std::string& name_, double value_){
+            parameters[name_]=value_;
+        }
+
+        double GetParameter(const std::string& name_) const{
+            return parameters.at(name_);
+        }
+
+        void SetParameters(const ParameterDict& paraDict_){
+            for (ParameterDict::const_iterator function =paraDict_.begin(); function != paraDict_.end(); ++function) {
+                std::set<std::string> holder=GetKeys(parameters);
+
+                if(holder.find(function->first)!=holder.end())
+                    SetParameter(function->first,function->second);
+            }
+        }
+
+        ParameterDict GetParameters() const{
+            return parameters;
+        }
+
+        size_t GetParameterCount() const{
+            return 2;
+        }
+
+        std::set<std::string> GetParameterNames() const {
+            std::set<std::string> names_;
+            names_.insert("grad");
+            names_.insert("offset");
+            return names_;
+        }
+
+        void RenameParameter(const std::string& old_, const std::string& new_){
+            parameters[new_]=parameters[old_];
+            parameters.erase(old_);
+        }
+
+        std::string GetName() const{
+            return fName;   
+        }
+
+        void SetName(const std::string& name_){
+            fName= name_;
+        }
+    private:
+        std::string fName;
+        ParameterDict parameters;
+};
+
+int main(int argc, char *argv[])
+{
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis1", 10, 30 ,200));
+
+    ObsSet  obsSet(0);
+    ObsSet  obsSetToTransform(0);
+
+    Convolution* conv_a = new Convolution("conv_a");
+    VaryingCDF smear("smear");
+
+    Gaussian* gaus_a = new Gaussian(0,10e4,"gaus_a"); 
+    Ploy* ploy = new Ploy("line",0.5,0);
+
+    gaus_a->RenameParameter("means_0","mean");
+    gaus_a->RenameParameter("stddevs_0","std");
+    //Set the kernal.
+    smear.SetKernel(gaus_a);
+
+    //Parameter std now runs like ploy.
+    smear.SetDependance("std",ploy);
+
+    conv_a->SetConditionalPDF(&smear);
+
+    conv_a->SetAxes(axes);
+    conv_a->SetTransformationObs(obsSetToTransform);
+    conv_a->SetDistributionObs(obsSet);
+    conv_a->Construct();
+
+    SparseMatrix mat = conv_a->GetResponse();
+    mat.Print("");
+
+    Gaussian gaus(20, 3);
+    BinnedED pdf("pdf", DistTools::ToHist(gaus, axes));
+    pdf.SetObservables(0);
+
+    pdf.Scale(40000);
+
+
+    TH1D Pdf = DistTools::ToTH1D(pdf);
+    TH1D PdfAfterSmear = DistTools::ToTH1D(conv_a->operator()(pdf));
+    TLegend leg(0.6,0.6,0.9,0.9); 
+    leg.AddEntry(&Pdf,"Before","lf"); 
+    leg.AddEntry(&PdfAfterSmear,"After","lf"); 
+
+    TCanvas c1;
+    gStyle->SetOptStat(kFALSE);  
+    Pdf.SetTitle("Before/After smear");
+    Pdf.SetLineColor(kRed);
+    Pdf.SetLineWidth(2);
+    Pdf.Scale(1./pdf.Integral());
+    Pdf.Draw();
+    PdfAfterSmear.SetLineColor(kBlue);
+    PdfAfterSmear.SetLineWidth(2);
+    PdfAfterSmear.Draw("same");
+    leg.Draw();
+    c1.Print("Smeared.png");
+                   
+
+
+    return 0;
+}

--- a/examples/VaryingCDF.cpp
+++ b/examples/VaryingCDF.cpp
@@ -1,3 +1,19 @@
+/************************************************************************
+ * In this example we use the VaryingCDF class to apply a smear which depends
+ * on the spectrum itself. We set up a VaryingCDF which takes a gaussian as its
+ * kernel and a function plot which governs the width of that kernel at that
+ * point in the spectrum. 
+ *
+ * Physics case here is that in perfect detector the energy resolutions depends
+ * on the nhit of the event. The width of this resolutions goes like
+ * sqrt(nhit), therefore it may be desirable to have an energy resolution which
+ * mirrors this dependence.  In the following the ploy function defines the
+ * functional dependence of the width of the gaussian kernel used to smear the
+ * spectrum.
+ * 
+ ************************************************************************/
+
+
 #include <string>        
 #include <vector>        
 #include <math.h>	
@@ -131,7 +147,7 @@ int main(int argc, char *argv[])
 
     gaus_a->RenameParameter("means_0","mean");
     gaus_a->RenameParameter("stddevs_0","std");
-    //Set the kernal.
+    // Set the kernal.
     smear.SetKernel(gaus_a);
 
     //Parameter std now runs like ploy.
@@ -152,7 +168,6 @@ int main(int argc, char *argv[])
     pdf.SetObservables(0);
 
     pdf.Scale(40000);
-
 
     TH1D Pdf = DistTools::ToTH1D(pdf);
     TH1D PdfAfterSmear = DistTools::ToTH1D(conv_a->operator()(pdf));

--- a/src/core/DenseMatrix.cpp
+++ b/src/core/DenseMatrix.cpp
@@ -117,3 +117,15 @@ DenseMatrix::SetSymmetricMatrix(const std::vector<double>& _input){
 	  }
       }
 }
+
+void 
+DenseMatrix::Print(const std::string& prefix_=""){
+    fArmaMat.print(prefix_);
+}
+
+void 
+DenseMatrix::PrintSparse(const std::string& prefix_=""){
+    arma::sp_mat B(fArmaMat);
+    B.print(prefix_);
+
+}

--- a/src/core/DenseMatrix.h
+++ b/src/core/DenseMatrix.h
@@ -30,6 +30,9 @@ class DenseMatrix{
 
     void SetSymmetricMatrix(const std::vector<double>& _input);
 
+    void   Print(const std::string&);
+    void   PrintSparse(const std::string&);
+
  private:
     // N x M matrix
     int fNRows;

--- a/src/core/SparseMatrix.cpp
+++ b/src/core/SparseMatrix.cpp
@@ -11,6 +11,18 @@ SparseMatrix::SparseMatrix(int rows_, int cols_){
 }
 
 void 
+SparseMatrix::PrintDense(const std::string& prefix_=""){
+    fArmaMat.print(prefix_);
+}
+
+void 
+SparseMatrix::Print(const std::string& prefix_=""){
+    arma::mat B(fArmaMat);
+    B.print(prefix_);
+
+}
+
+void 
 SparseMatrix::SetComponent(size_t row_, size_t col_, double val_){
     if (col_ >= fNCols || row_ >= fNRows)
         throw NotFoundError(Formatter() 

--- a/src/core/SparseMatrix.h
+++ b/src/core/SparseMatrix.h
@@ -32,6 +32,9 @@ class SparseMatrix{
     void   SetZeros();
     void   SetToIdentity();
 
+    void   Print(const std::string&);
+    void   PrintDense(const std::string&);
+
  private:
     arma::sp_mat fArmaMat;
     int fNRows;

--- a/src/function/VaryingCDF.cpp
+++ b/src/function/VaryingCDF.cpp
@@ -1,0 +1,187 @@
+#include <VaryingCDF.h>
+#include <Exceptions.h>
+#include <ContainerTools.hpp>
+#include <ContainerParameter.h>
+#include <ContainerTools.hpp>
+#include <Formatter.hpp>
+#include <Rand.h>
+#include <PDF.h>
+#include <JumpPDF.h>
+
+using ContainerTools::ToString;
+using ContainerTools::GetKeys;
+using ContainerTools::GetValues;
+
+/////////////////////////
+// Constructory Things //
+/////////////////////////
+
+VaryingCDF::VaryingCDF(const std::string& name_ = ""){
+    if(name_=="")
+        fName=std::string("VaryingCDF");
+    else
+        fName=name_;
+}
+VaryingCDF::~VaryingCDF(){
+    delete fCdf;
+    for(std::map<std::string,Function*>::const_iterator parameter_ = fFunctions.begin(); parameter_ !=fFunctions.end(); ++parameter_) {
+        delete parameter_->second;
+    }
+}
+
+VaryingCDF::VaryingCDF(const VaryingCDF& copy_){
+    fFunctions = copy_.fFunctions;
+    fCdf = copy_.fCdf->Clone();
+    fName = copy_.fName;
+}
+
+VaryingCDF&
+VaryingCDF::operator=(const VaryingCDF& copy_){
+    fFunctions = copy_.fFunctions;
+    fCdf = copy_.fCdf->Clone();
+    fName = copy_.fName;
+    return *this;
+}
+
+ConditionalPDF*
+VaryingCDF::Clone() const{
+    return static_cast<ConditionalPDF*> (new VaryingCDF(*this));
+}
+
+ParameterDict
+VaryingCDF::SetupParameters(const std::vector<double>& x2_) const {
+    ParameterDict parameters;
+    for(std::map<std::string,Function*>::const_iterator parameter_ = fFunctions.begin(); parameter_ !=fFunctions.end(); ++parameter_) {
+        parameters[parameter_->first] = (parameter_->second)->operator()(x2_);
+    }
+    return parameters;
+}
+
+double
+VaryingCDF::ConditionalProbability(const std::vector<double>& x_, 
+                                   const std::vector<double>& x2_){
+    if (!fCdf)
+        throw NULLPointerAccessError(Formatter()<<"VaryingCDF:: fCdf is not pointing to a PDF.");
+    fCdf->SetParameters(SetupParameters(x2_));
+    return fCdf->ConditionalProbability(x_,x2_);
+}
+
+void
+VaryingCDF::SetDependance(const std::string& paraName_, const Function* func_){
+    fFunctions[paraName_] = func_->Clone();
+}
+
+double
+VaryingCDF::Integral(const std::vector<double>& mins_, 
+                              const std::vector<double>& maxs_,
+                              const std::vector<double>& x2_) const{
+    if (!fCdf)
+        throw NULLPointerAccessError(Formatter()<<"VaryingCDF:: fCdf is not pointing to a ConditionalPDF.");
+    fCdf->SetParameters(SetupParameters(x2_));
+    return fCdf->Integral(mins_,maxs_,x2_);
+}
+
+void 
+VaryingCDF::SetKernel(ConditionalPDF* PDF_){
+    fCdf=PDF_->Clone();
+}
+
+void 
+VaryingCDF::SetKernel(PDF* PDF_){
+    // BL : If we are passed a PDF we transform to a JumpPDF in order to perserve
+    // the structure of shifting a function to a bin center and integrating over
+    // over bins relative to that shift.
+    fCdf=static_cast<ConditionalPDF*>(new JumpPDF("kernel",PDF_));
+}
+
+std::vector<double>
+VaryingCDF::Sample(const std::vector<double>& x2_) const{
+    if (!fCdf)
+        throw NULLPointerAccessError(Formatter()<<"VaryingCDF:: fCdf is not pointing to a ConditionalPDF.");
+    fCdf->SetParameters(SetupParameters(x2_));
+    return fCdf->Sample(x2_);
+}
+
+void 
+VaryingCDF::SetParameter(const std::string& name_, double value_){
+    for (std::map<std::string,Function*>::iterator function = fFunctions.begin(); function != fFunctions.end(); ++function) {
+        function->second->SetParameter(name_,value_);
+    }
+}
+
+double 
+VaryingCDF::GetParameter(const std::string& name_) const{
+    //This reutrns parameters of the parameter functions that have been defined.
+    size_t changed = 0;
+    double holder=0;
+    for (std::map<std::string,Function*>::const_iterator function = fFunctions.begin(); function != fFunctions.end(); ++function) {
+        try {
+            holder = function->second->GetParameter(name_);
+            changed = 1;
+        }catch(const NotFoundError& e_) {
+            ;
+        }
+        return holder;
+    }
+    if (changed !=1){
+            std::vector<std::string> functionNames;
+            for (std::map<std::string,Function*>::const_iterator function = fFunctions.begin(); function != fFunctions.end(); ++function) {
+                functionNames.push_back(function->second->GetName());
+            }
+            throw NotFoundError(Formatter() << "VaryingCDF:: Parameter : " << name_ <<" not found in fFunctions available. Functions available: "
+                    << ToString(functionNames)<<" Parameters available : "<<ToString(GetParameterNames()) ); 
+    }
+}
+
+void
+VaryingCDF::SetParameters(const ParameterDict& paraDict_){
+    for (std::map<std::string,Function*>::const_iterator function = fFunctions.begin(); function != fFunctions.end(); ++function) {
+        function->second->SetParameters(paraDict_);
+    }
+}
+
+ParameterDict
+VaryingCDF::GetParameters() const{
+    ParameterDict paraDict_;
+    for (std::map<std::string,Function*>::const_iterator function = fFunctions.begin(); function != fFunctions.end(); ++function) {
+        ParameterDict holder = function->second->GetParameters();
+        paraDict_.insert(holder.begin(), holder.end());
+    }
+    return paraDict_;
+}
+
+size_t
+VaryingCDF::GetParameterCount() const{
+    size_t number=0;
+    for (std::map<std::string,Function*>::const_iterator function = fFunctions.begin(); function != fFunctions.end(); ++function) {
+        number += function->second->GetParameterCount();
+    }
+    return number;
+}
+
+std::set<std::string>
+VaryingCDF::GetParameterNames() const {
+    std::set<std::string> names_;
+    for (std::map<std::string,Function*>::const_iterator function = fFunctions.begin(); function != fFunctions.end(); ++function) {
+        std::set<std::string> holder = function->second->GetParameterNames();
+        names_.insert(holder.begin(), holder.end());
+    }
+    return names_;
+}
+
+void
+VaryingCDF::RenameParameter(const std::string& old_, const std::string& new_){
+    for (std::map<std::string,Function*>::const_iterator function = fFunctions.begin(); function != fFunctions.end(); ++function) {
+        function->second->RenameParameter(old_,new_);
+    }
+}
+
+std::string
+VaryingCDF::GetName() const{
+    return fName;   
+}
+
+void 
+VaryingCDF::SetName(const std::string& name_){
+    fName= name_;
+}

--- a/src/function/VaryingCDF.cpp
+++ b/src/function/VaryingCDF.cpp
@@ -88,7 +88,7 @@ VaryingCDF::SetKernel(ConditionalPDF* PDF_){
 
 void 
 VaryingCDF::SetKernel(PDF* PDF_){
-    // BL : If we are passed a PDF we transform to a JumpPDF in order to perserve
+    // BL : If we are passed a PDF we transform to a JumpPDF in order to preserve
     // the structure of shifting a function to a bin center and integrating over
     // over bins relative to that shift.
     fCdf=static_cast<ConditionalPDF*>(new JumpPDF("kernel",PDF_));
@@ -111,7 +111,7 @@ VaryingCDF::SetParameter(const std::string& name_, double value_){
 
 double 
 VaryingCDF::GetParameter(const std::string& name_) const{
-    //This reutrns parameters of the parameter functions that have been defined.
+    //This returns parameters of the parameter functions that have been defined.
     size_t changed = 0;
     double holder=0;
     for (std::map<std::string,Function*>::const_iterator function = fFunctions.begin(); function != fFunctions.end(); ++function) {

--- a/src/function/VaryingCDF.h
+++ b/src/function/VaryingCDF.h
@@ -1,0 +1,58 @@
+#ifndef __OXSX_VARYING_PARAMETER_PDF__
+#define __OXSX_VARYING_PARAMETER_PDF__
+#include <string>
+#include <map>
+#include <vector>
+
+#include <PDF.h>
+#include <ConditionalPDF.h>
+#include <ParameterDict.h>
+#include <Function.h>
+#include <algorithm>
+
+class VaryingCDF : public ConditionalPDF{
+ public:
+    VaryingCDF(const std::string&);
+    ~VaryingCDF();
+
+    VaryingCDF(const VaryingCDF& copy_);
+
+    VaryingCDF& operator=(const VaryingCDF& other_);
+
+    double ConditionalProbability(const std::vector<double>& x_, 
+            const std::vector<double>& x2_);
+    double Integral(const std::vector<double>& mins_, 
+                    const std::vector<double>& maxs_,
+                    const std::vector<double>& x2_) const;
+
+    std::vector<double> Sample(const std::vector<double>&) const;
+
+    ConditionalPDF* Clone() const;
+
+    void SetKernel(ConditionalPDF* PDF_);
+    void SetKernel(PDF* PDF_);
+    void SetDependance(const std::string& paraName_, const Function* func_);
+
+    ParameterDict SetupParameters(const std::vector<double>& x2_) const;
+
+    // FitParameter interface.
+    void   SetParameter(const std::string& name_, double value);
+    double GetParameter(const std::string& name_) const;
+
+    void   SetParameters(const ParameterDict&);
+    ParameterDict GetParameters() const;
+    size_t GetParameterCount() const;
+
+    std::set<std::string> GetParameterNames() const;
+    void   RenameParameter(const std::string& old_, const std::string& new_);
+
+    std::string GetName() const;
+    void SetName(const std::string&);
+
+ private:
+    std::map<std::string, Function*> fFunctions;
+    ConditionalPDF* fCdf;
+    
+    std::string fName;
+};
+#endif

--- a/src/function/VaryingCDF.h
+++ b/src/function/VaryingCDF.h
@@ -1,3 +1,34 @@
+/************************************************************************
+ * VaryingCDF is a CDF who's parameters are governed by a general function of
+ * inputs.
+ *
+ * Use case : A spectrum's resolution may have some functional dependence on
+ * the spectrum itself. Convolving the spectrum with a gaussian of constant
+ * width doesn't encode this functional dependence. The VaryingCDF can take the
+ * gaussian (or any function) as it's kernel and change the parameters of this
+ * kernel by some general function dependent on the current spectrum point. 
+ *
+ * Usages:
+ *    Gaussian gaus("gaus",0,1);
+ *    gaus.RenameParameter("means_0","mean");
+ *    gaus.RenameParameter("stddevs_0","std");
+ *    VaryingCDF smearer("smearer");
+ *    smearer.SetKernal(&gaus)
+ *    smearer.SetDependance
+ *    smearer.SetDependance("std",ploy(see note));
+ *
+ * The above creates a VaryingCDF whose gaussian kernel has a variable
+ * stddev which goes like the function ploy.
+
+ * Note:
+ * Where 'ploy' is a function that takes a vector of doubles that
+ * represents the bin in which you are evaluating on e.g. fitting in r,E
+ * ploy will take a vector = [r_i,E_j]. The order of the vector is the same
+ * as the order in which the axes of the fit were set.
+ * 
+ ************************************************************************/
+
+
 #ifndef __OXSX_VARYING_PARAMETER_PDF__
 #define __OXSX_VARYING_PARAMETER_PDF__
 #include <string>

--- a/test/unit/VaryingCDFTest.cpp
+++ b/test/unit/VaryingCDFTest.cpp
@@ -1,0 +1,145 @@
+#include <catch.hpp>
+#include <iostream>
+
+#include <VaryingCDF.h>
+#include <Exceptions.h>
+#include <ContainerTools.hpp>
+#include <ParameterDict.h>
+#include <Function.h>
+#include <Gaussian.h>
+#include <math.h>
+
+
+using ContainerTools::ToString;
+using ContainerTools::GetValues;
+using ContainerTools::GetKeys;
+
+class Ploy : public Function{
+    public:
+        // Constructory things
+        Ploy(const std::string& name_,const double grad, const double offset){
+            fName=name_;
+            parameters["grad"]=grad;
+            parameters["offset"]=offset;
+        }
+
+        Ploy(const Ploy& copy_){
+            fName=copy_.fName;
+            parameters=copy_.parameters;
+        }
+
+
+        Ploy& operator=(const Ploy& copy_){
+            fName=copy_.fName;
+            parameters=copy_.parameters;
+            return *this;
+        }
+
+        // Probability
+        double operator()(const std::vector<double>& vals_) const{
+            return parameters.at("grad")*vals_[0]+parameters.at("offset");
+        }
+
+        int GetNDims() const{
+            return 1;
+        }
+
+        Function* Clone() const{
+            return static_cast<Function*> (new Ploy(*this));
+        }
+
+        void SetParameter(const std::string& name_, double value_){
+            parameters[name_]=value_;
+        }
+
+        double GetParameter(const std::string& name_) const{
+            return parameters.at(name_);
+        }
+
+        void SetParameters(const ParameterDict& paraDict_){
+            for (ParameterDict::const_iterator function =paraDict_.begin(); function != paraDict_.end(); ++function) {
+                std::set<std::string> holder=GetKeys(parameters);
+
+                if(holder.find(function->first)!=holder.end())
+                    SetParameter(function->first,function->second);
+            }
+        }
+
+        ParameterDict GetParameters() const{
+            return parameters;
+        }
+
+        size_t GetParameterCount() const{
+            return 2;
+        }
+
+        std::set<std::string> GetParameterNames() const {
+            std::set<std::string> names_;
+            names_.insert("grad");
+            names_.insert("offset");
+            return names_;
+        }
+
+        void RenameParameter(const std::string& old_, const std::string& new_){
+            parameters[new_]=parameters[old_];
+            parameters.erase(old_);
+        }
+
+        std::string GetName() const{
+            return fName;   
+        }
+
+        void SetName(const std::string& name_){
+            fName= name_;
+        }
+    private:
+        std::string fName;
+        ParameterDict parameters;
+};
+
+TEST_CASE("Varying CDF 1 Parameter", "[VaryingCDF]"){
+    Ploy ploy("ploy",1,0);
+    Gaussian gaus(0, 8);
+    VaryingCDF smearer("smearer");
+    smearer.SetKernel(&gaus);
+    smearer.SetDependance("stddevs_0",&ploy);
+
+    SECTION("Check name"){
+        REQUIRE(smearer.GetName()=="smearer");
+    }
+    SECTION("Check probability"){
+        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1))==Approx(0.6827));
+        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2))==Approx(0.6827));
+    }
+}
+
+TEST_CASE("Varying CDF 2 parameter", "[VaryingCDF]"){
+    Ploy ployMean("ployMean",0,0);
+    Ploy ployStd("ployStd",1,0);
+    Gaussian gaus(0, 8);
+    VaryingCDF smearer("smearer");
+    smearer.SetKernel(&gaus);
+    smearer.SetDependance("means_0",&ployMean);
+    smearer.SetDependance("stddevs_0",&ployStd);
+
+    SECTION("Check probability"){
+        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1))==Approx(0.6827));
+        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2))==Approx(0.6827));
+    }
+}
+
+TEST_CASE("Varying CDF 2 parameter TWO", "[VaryingCDF]"){
+    Ploy ployMean("ployMean",2,0);
+    Ploy ployStd("ployStd",1,0);
+    Gaussian gaus(0, 8);
+    VaryingCDF smearer("smearer");
+    smearer.SetKernel(&gaus);
+    smearer.SetDependance("means_0",&ployMean);
+    smearer.SetDependance("stddevs_0",&ployStd);
+
+    SECTION("Check probability"){
+        // You are centered at 1, the mean shifts by 2 there the gaussian is about 3  with a stddev of 1. Therefore integrate between [2,4].
+        REQUIRE(smearer.Integral(std::vector<double>(1,2),std::vector<double>(1,4),std::vector<double>(1,1))==Approx(0.6827));
+    }
+}
+


### PR DESCRIPTION
Added VaryingCDF, a general parameter dependant CDF. Also added Print functionality to the matrix classes.

A VaryingCDF is a CDF whose underlying generating kernels parameters
(e.g. the stdev of the Gaussian that makes the matrix) can depend on
general functions of the fit parameters.

Also added print functions to the matrix classes.

Usage:

   Gaussian gaus("gaus",0,1);
   gaus.RenameParameter("means_0","mean");
   gaus.RenameParameter("stddevs_0","std");
   VaryingCDF smearer("smearer");
   smearer.SetKernal(&gaus)
   smearer.SetDependance("std",ploy(see note));

   The above creates a VaryingCDF whose gaussian kernel has a variable
   stddev which goes like the function ploy.

   note:
   Where 'ploy' is a function that takes a vector of doubles that
   represents the bin in which you are evaluating on e.g. fitting in r,E
   ploy will take a vector = [r_i,E_j]. The order of the vector is the same
   as the order in which the axes of the fit were set.