### PR TITLE
Systematics can be associated with a group of EDs.

### DIFF
--- a/examples/simpleFit.cpp
+++ b/examples/simpleFit.cpp
@@ -57,8 +57,8 @@ int main(){
     ROOTNtuple dataNt(dataFile, dataTreeName);
     BinnedNLLH lhFunction;        
     lhFunction.SetDataSet(&dataNt); // initialise withe the data set
-    lhFunction.AddPdf(bgPdf);        
-    lhFunction.AddPdf(signalPdf);        
+    lhFunction.AddDist(bgPdf);        
+    lhFunction.AddDist(signalPdf);        
         
     std::cout << "Built LH function " << std::endl;        
          

--- a/examples/simpleSystematicFit.cpp
+++ b/examples/simpleSystematicFit.cpp
@@ -1,0 +1,289 @@
+#include <string>        
+#include <vector>        
+#include <math.h>	
+#include <Rand.h>
+#include <fstream>
+
+#include <TH1D.h>        
+#include <TPaveText.h> 
+#include <TCanvas.h> 
+#include <TLegend.h> 
+#include <TStyle.h> 
+#include <TPad.h> 
+#include <TPaveStats.h> 
+
+#include <BinnedED.h>        
+#include <BinnedEDGenerator.h>
+#include <SystematicManager.h>
+#include <BinnedNLLH.h>
+#include <FitResult.h>
+#include <Minuit.h>
+#include <DistTools.h>
+#include <Minuit.h>
+#include <Convolution.h>
+#include <Scale.h>
+#include <BoolCut.h>
+#include <BoxCut.h>
+#include <Gaussian.h>
+#include <ParameterDict.h>
+#include <ContainerTools.hpp>
+
+TH1D* diffHist(TH1D * h1,TH1D * h2);
+void padPDFs(std::vector<BinnedED>& binnedEDList);
+
+void
+function(){
+
+    Rand::SetSeed(0);
+
+    Gaussian gaus1(20, 1.0);
+    Gaussian gaus2(15, 0.5);
+
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis1", 0, 50 ,200));
+
+    BinnedED pdf3("a_data", DistTools::ToHist(gaus1, axes));
+    BinnedED pdf1("a_mc", DistTools::ToHist(gaus2, axes));
+
+    pdf1.SetObservables(0);
+    pdf3.SetObservables(0);
+
+    pdf1.Scale(100000);
+
+    std::vector<BinnedED> dataPdfs;
+    dataPdfs.push_back(pdf3);
+    padPDFs(dataPdfs);
+
+    BinnedEDGenerator dataGen;
+    dataGen.SetPdfs(dataPdfs);
+    std::vector<double> rates(1,100000);
+    dataGen.SetRates(rates);
+
+    // BinnedED fakeData= dataGen.ExpectedRatesED();
+    BinnedED fakeData= dataGen.PoissonFluctuatedED();
+
+    pdf1.Normalise();
+    std::vector<BinnedED> mcPdfs;
+    mcPdfs.push_back(pdf1);
+
+    padPDFs(mcPdfs);
+
+    ObsSet  obsSet(0);
+
+    Convolution* conv_a = new Convolution("conv_a");
+    Gaussian* gaus_a = new Gaussian(0,1,"gaus_a"); 
+    gaus_a->RenameParameter("means_0","gaus_a_1");
+    gaus_a->RenameParameter("stddevs_0","gaus_a_2");
+
+    conv_a->SetFunction(gaus_a);
+
+    conv_a->SetAxes(axes);
+    conv_a->SetTransformationObs(obsSet);
+    conv_a->SetDistributionObs(obsSet);
+    conv_a->Construct();
+
+    // Setting optimisation limits
+    ParameterDict minima;
+    minima["a_mc_norm"] = 10; 
+    minima["gaus_a_1" ] = -15;
+    minima["gaus_a_2" ] = 0;  
+
+    ParameterDict maxima;
+    maxima["a_mc_norm"] = 200000;
+    maxima["gaus_a_1" ] = 15;    
+    maxima["gaus_a_2" ] = 1;     
+
+    // ParameterDict initialval;
+    // Rand rand;
+    // initialval["a_mc_norm"] = rand.UniformRange(minima["a_mc_norm"],maxima["a_mc_norm"]); 
+    // initialval["gaus_a_1" ] = rand.UniformRange(minima["gaus_a_1" ],maxima["gaus_a_1" ]); 
+    // initialval["gaus_a_2" ] = rand.UniformRange(minima["gaus_a_2" ],maxima["gaus_a_2" ]); 
+
+    ParameterDict initialval;
+    initialval["a_mc_norm"] = 90000; 
+    initialval["gaus_a_1"]  = 4.;   
+    initialval["gaus_a_2"]  = 1.;    
+
+    ParameterDict initialerr;
+    initialerr["a_mc_norm"] = 0.1*initialval["a_mc_norm"];
+    initialerr["gaus_a_1" ] = 0.1*initialval["gaus_a_1"]; 
+    initialerr["gaus_a_2" ] = 0.1*initialval["gaus_a_2"]; 
+
+    //Setting up likelihood.
+    int BuffLow  = 20;
+    int BuffHigh = 20;
+
+    BinnedNLLH lh; 
+    lh.SetBufferAsOverflow(false);
+    lh.SetBuffer(0,BuffLow,BuffHigh);
+    lh.SetDataDist(fakeData); // initialise with the data set
+    //Add systematics to groups.
+    lh.AddSystematic(conv_a);
+
+    // Associate EDs with a vector of groups.
+    lh.AddDist(mcPdfs.at(0));
+
+    Minuit min;
+    min.SetMethod("Simplex");
+    min.SetMaxCalls(10000000);
+    min.SetMinima(minima);
+    min.SetMaxima(maxima);
+    min.SetInitialValues(initialval);
+    min.SetInitialErrors(initialerr);
+
+    std::cout << "About to Fit" << std::endl;
+    FitResult result = min.Optimise(&lh);
+    result.SetPrintPrecision(4);
+    result.Print();
+    ParameterDict bestResult = result.GetBestFit();
+
+    // Plot Result
+    {
+        BinnedED BiHolder = mcPdfs.at(0);
+        BinnedED BiResult;
+
+        Convolution BiSmearer("aConv");
+        BiSmearer.SetFunction(new Gaussian(bestResult.at("gaus_a_1"),bestResult.at("gaus_a_2")));
+        BiSmearer.SetAxes(axes);
+        BiSmearer.SetTransformationObs(obsSet);
+        BiSmearer.SetDistributionObs(obsSet);
+        BiSmearer.Construct();
+
+
+        BiResult = BiSmearer( BiHolder );
+
+        BiResult.Scale(bestResult.at("a_mc_norm"));
+
+        TH1D fakeDataHist;
+        TH1D BiFit;
+        BiFit.Sumw2();
+        fakeDataHist = DistTools::ToTH1D(fakeData);
+        BiFit= DistTools::ToTH1D(BiResult);
+
+        TH1D FullFit("FullFit","",BiFit.GetNbinsX(),BiFit.GetXaxis()->GetXmin(),BiFit.GetXaxis()->GetXmax());
+        FullFit.Sumw2();
+
+        FullFit.Add(&BiFit);
+
+        TLegend* leg =new TLegend(0.8,0.7,1,0.9); 
+        leg->AddEntry(&fakeDataHist,"FakeData","lf"); 
+        leg->AddEntry(&BiFit,"a fit result","lf"); 
+
+        TCanvas* diff = new TCanvas("diff","",800,800);
+        diff->cd(); 
+        // -------------- Top panel 
+        gStyle->SetOptStat(kFALSE);  
+        TPad *pad1 = new TPad("pad1","pad1",0,0.3,1,1); 
+        pad1->Draw(); 
+        pad1->SetLogy(1); 
+        pad1->cd(); 
+        pad1->SetGrid(kTRUE); 
+        pad1->SetBottomMargin(0.00); 
+        gPad->RedrawAxis();  
+
+        fakeDataHist.SetTitle("Independent Systematic Fit");
+        fakeDataHist.GetYaxis()->SetTitle(Form("Counts"));
+        fakeDataHist.GetYaxis()->SetTitleOffset(1.5); 
+        fakeDataHist.SetFillColorAlpha(kGreen,0.5); 
+
+        fakeDataHist.Draw(); 
+        FullFit.SetFillColorAlpha(kRed,0.5); 
+        BiFit.SetLineColor(kRed);
+        BiFit.SetLineWidth(3);
+        BiFit.Draw("same e"); 
+
+        TH1D hist1 =  DistTools::ToTH1D(pdf1);
+        hist1.Scale(4000);
+
+        hist1.SetFillColorAlpha(kRed,0.5); 
+        hist1.SetLineWidth(2);
+        hist1.Draw("same");
+
+        leg->AddEntry(&hist1,"a pdf","lf"); 
+        leg->Draw(); 
+
+        TPaveText pt(0.7,0.2,1.0,0.6,"NDC");
+        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc_norm"]));
+        pt.AddText(Form("a conv mean = %.2f",bestResult["gaus_a_1"]));
+        pt.AddText(Form("a conv RMS= %.2f",bestResult["gaus_a_2"]));
+        pt.SetFillColor(kWhite);
+        pt.SetShadowColor(kWhite);
+        pt.Draw();
+        diff->cd(); 
+
+        // -------------- Bottom panel 
+        TPad *pad2 = new TPad("pad2","pad2",0,0.0,1,0.3); 
+        pad2->SetTopMargin(0.00); 
+        pad2->Draw(); 
+        pad2->cd(); 
+        pad2->SetBottomMargin(0.3); 
+        pad2->SetGrid(kTRUE); 
+        gStyle->SetOptStat(kFALSE);  
+
+        TH1D * fracDiff= diffHist(&fakeDataHist,&FullFit); 
+        fracDiff->SetLineWidth(2); 
+
+        fracDiff->GetXaxis()->SetTitle("axis1"); 
+        fracDiff->GetYaxis()->SetTitle("Fit / Fake Data"); 
+        fracDiff->GetYaxis()->SetTitleOffset(0.5); 
+        fracDiff->GetXaxis()->SetLabelSize(0.1); 
+        fracDiff->GetXaxis()->SetTitleSize(0.1); 
+        fracDiff->GetYaxis()->SetLabelSize(0.1); 
+        fracDiff->GetYaxis()->SetTitleSize(0.1); 
+
+        fracDiff->SetMaximum(2); 
+        fracDiff->SetMinimum(0); 
+        fracDiff->Draw(); 
+
+        diff->Print("simpleSystematicFitExample.png"); 
+    }
+
+}
+
+int main(int argc, char *argv[]){
+
+    function();
+    return 0;
+
+}
+
+TH1D* diffHist(TH1D * h1,TH1D * h2){
+    double minBin=h1->GetXaxis()->GetXmin();
+    double maxBin=h1->GetXaxis()->GetXmax();
+    double numOfBins=h1->GetNbinsX();
+
+    TH1D* rhist = new TH1D("rhist","",numOfBins,minBin,maxBin);
+    for(double i=0;i<numOfBins;i++){
+        double h1cont=h1->GetBinContent(i);
+        double h2cont=h2->GetBinContent(i);
+        double weight;
+        double error;
+        if (h1cont!=0 && h1cont-h2cont!=0) {
+            weight= h2cont/h1cont;
+            error= weight * sqrt(1/sqrt(h2cont) + 1/sqrt(h1cont));
+            // weight= (h1cont-h2cont)/h1cont;
+        } else {
+            // How else do you fix this?
+            weight= 10000000;
+            error = 0;
+        }
+        rhist->SetBinContent(i,weight);
+        rhist->SetBinError(i,error);
+    }
+    return rhist;
+}
+
+void padPDFs(std::vector<BinnedED>& binnedEDList){
+    std::cout<<"Padding Now"<<std::endl;
+    for(int i=0;i<binnedEDList.size();i++){
+        std::vector<double> bincontent =binnedEDList.at(i).GetBinContents();
+        std::vector<double> new_bincontent;
+        for(int j =0; j<bincontent.size();j++){
+            if(bincontent.at(j)==0)
+                new_bincontent.push_back(std::numeric_limits< double >::min());
+            else
+                new_bincontent.push_back(bincontent[j]);
+        }
+        binnedEDList[i].SetBinContents(new_bincontent);
+    }
+}

--- a/examples/systematicFit.cpp
+++ b/examples/systematicFit.cpp
@@ -1,0 +1,902 @@
+#include <string>        
+#include <vector>        
+#include <math.h>	
+#include <Rand.h>
+#include <fstream>
+
+#include <TH1D.h>        
+#include <TPaveText.h> 
+#include <TCanvas.h> 
+#include <TLegend.h> 
+#include <TStyle.h> 
+#include <TPad.h> 
+#include <TPaveStats.h> 
+
+#include <BinnedED.h>        
+#include <BinnedEDGenerator.h>
+#include <SystematicManager.h>
+#include <BinnedNLLH.h>
+#include <FitResult.h>
+#include <Minuit.h>
+#include <DistTools.h>
+#include <Minuit.h>
+#include <Convolution.h>
+#include <Scale.h>
+#include <BoolCut.h>
+#include <BoxCut.h>
+#include <Gaussian.h>
+#include <ParameterDict.h>
+#include <ContainerTools.hpp>
+
+TH1D* diffHist(TH1D * h1,TH1D * h2);
+void padPDFs(std::vector<BinnedED>& binnedEDList);
+
+void function1();
+void function2();
+void function3();
+
+int main(int argc, char *argv[]){
+    // Using groups of systematics.
+    function1();
+    // Using global of systematics.
+    function2();
+    // Using both global systematics with groups of systematics.
+    function3();
+    return 0;
+}
+
+void
+function1(){
+
+    Rand::SetSeed(0);
+    Gaussian gaus1(10, 0.65);
+    Gaussian gaus2(15, 0.5);
+    Gaussian gaus3(20, 0.5);
+    Gaussian gaus4(30, 1.0);
+
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis1", 0, 50 ,200));
+
+    // Making PDFs. 
+    BinnedED pdf3("a_data", DistTools::ToHist(gaus1, axes));
+    BinnedED pdf1("a_mc", DistTools::ToHist(gaus2, axes));
+    // Making fake data.
+    BinnedED pdf4("b_data", DistTools::ToHist(gaus4, axes));
+    BinnedED pdf2("b_mc", DistTools::ToHist(gaus3, axes));
+
+    pdf1.SetObservables(0);
+    pdf2.SetObservables(0);    
+    pdf3.SetObservables(0);
+    pdf4.SetObservables(0);
+
+    pdf1.Scale(100000);
+    pdf2.Scale(100000);    
+
+    std::vector<BinnedED> dataPdfs;
+    dataPdfs.push_back(pdf3);
+    dataPdfs.push_back(pdf4);
+    padPDFs(dataPdfs);
+
+    BinnedEDGenerator dataGen;
+    dataGen.SetPdfs(dataPdfs);
+    std::vector<double> rates(2,100000);
+    dataGen.SetRates(rates);
+
+    // BinnedED fakeData= dataGen.ExpectedRatesED();
+    // Fluctuate data.
+    BinnedED fakeData= dataGen.PoissonFluctuatedED();
+
+    pdf1.Normalise();
+    pdf2.Normalise();    
+    std::vector<BinnedED> mcPdfs;
+    mcPdfs.push_back(pdf1);
+    mcPdfs.push_back(pdf2);
+
+    padPDFs(mcPdfs);
+
+    ObsSet  obsSet(0);
+
+    Convolution* conv_a = new Convolution("conv_a");
+    Gaussian* gaus_a = new Gaussian(0,1,"gaus_a"); 
+    gaus_a->RenameParameter("means_0","gaus_a_1");
+    gaus_a->RenameParameter("stddevs_0","gaus_a_2");
+
+    conv_a->SetFunction(gaus_a);
+
+    conv_a->SetAxes(axes);
+    conv_a->SetTransformationObs(obsSet);
+    conv_a->SetDistributionObs(obsSet);
+    conv_a->Construct();
+
+    Convolution* conv_b = new Convolution("conv_b");
+    Gaussian * gaus_b = new Gaussian(0,1,"gaus_b"); 
+    gaus_b->RenameParameter("means_0","gaus_b_1");
+    gaus_b->RenameParameter("stddevs_0","gaus_b_2");
+    conv_b->SetFunction(gaus_b);
+    conv_b->SetAxes(axes);
+    conv_b->SetTransformationObs(obsSet);
+    conv_b->SetDistributionObs(obsSet);
+    conv_b->Construct();
+
+    // Setting optimisation limits
+    ParameterDict minima;
+    minima["a_mc_norm"] = 10; 
+    minima["b_mc_norm"] = 10; 
+    minima["gaus_a_1" ] = -15;
+    minima["gaus_a_2" ] = 0;  
+    minima["gaus_b_1" ] = -15;
+    minima["gaus_b_2" ] = 0;  
+
+    ParameterDict maxima;
+    maxima["a_mc_norm"] = 200000;
+    maxima["b_mc_norm"] = 200000;
+    maxima["gaus_a_1" ] = 15;    
+    maxima["gaus_a_2" ] = 1;     
+    maxima["gaus_b_1" ] = 16.;   
+    maxima["gaus_b_2" ] = 1;     
+
+
+    // ParameterDict initialval;
+    // Rand rand;
+    // initialval["a_mc_norm"] = rand.UniformRange(minima["a_mc_norm"],maxima["a_mc_norm"]); 
+    // initialval["b_mc_norm"] = rand.UniformRange(minima["b_mc_norm"],maxima["b_mc_norm"]); 
+    // initialval["gaus_a_1" ] = rand.UniformRange(minima["gaus_a_1" ],maxima["gaus_a_1" ]); 
+    // initialval["gaus_a_2" ] = rand.UniformRange(minima["gaus_a_2" ],maxima["gaus_a_2" ]); 
+    // initialval["gaus_b_1" ] = rand.UniformRange(minima["gaus_b_1" ],maxima["gaus_b_1" ]); 
+    // initialval["gaus_b_2" ] = rand.UniformRange(minima["gaus_b_2" ],maxima["gaus_b_2" ]); 
+
+    ParameterDict initialval;
+    initialval["a_mc_norm"] = 90000; 
+    initialval["b_mc_norm"] = 90000; 
+    initialval["gaus_a_1"]  = -4.;   
+    initialval["gaus_a_2"]  = 1.;    
+    initialval["gaus_b_1"]  = 9.;    
+    initialval["gaus_b_2"]  = 1.;    
+
+    ParameterDict initialerr;
+    initialerr["a_mc_norm"] = 0.1*initialval["a_mc_norm"];
+    initialerr["b_mc_norm"] = 0.1*initialval["b_mc_norm"];
+    initialerr["gaus_a_1" ] = 0.1*initialval["gaus_a_1"]; 
+    initialerr["gaus_a_2" ] = 0.1*initialval["gaus_a_2"]; 
+    initialerr["gaus_b_1" ] = 0.1*initialval["gaus_b_1"]; 
+    initialerr["gaus_b_2" ] = 0.1*initialval["gaus_b_2"]; 
+
+    //Setting up likelihood.
+    int BuffLow  = 20;
+    int BuffHigh = 20;
+
+    BinnedNLLH lh; 
+    lh.SetBufferAsOverflow(false);
+    lh.SetBuffer(0,BuffLow,BuffHigh);
+    lh.SetDataDist(fakeData); // initialise with the data set
+    
+    // Add systematics to groups. The order in which the systematic is added to
+    // the group is the same as the order in which they are applied.
+    lh.AddSystematic(conv_a,"aGroup");
+    lh.AddSystematic(conv_b,"bGroup");
+
+    // Associate EDs with a vector of groups. The order of the vector of groups
+    // is the same as the order in which they are applied.
+    lh.AddDist(mcPdfs.at(0),std::vector<std::string>(1,"aGroup"));
+    lh.AddDist(mcPdfs.at(1),std::vector<std::string>(1,"bGroup"));
+
+    Minuit min;
+    min.SetMethod("Simplex");
+    min.SetMaxCalls(10000000);
+    min.SetMinima(minima);
+    min.SetMaxima(maxima);
+    min.SetInitialValues(initialval);
+    min.SetInitialErrors(initialerr);
+
+    std::cout << "function1 : About to Fit" << std::endl;
+    FitResult result = min.Optimise(&lh);
+    result.SetPrintPrecision(4);
+    result.Print();
+    ParameterDict bestResult = result.GetBestFit();
+
+    // Plot Result
+    {
+        BinnedED BiHolder = mcPdfs.at(0);
+        BinnedED PoHolder = mcPdfs.at(1);
+        BinnedED BiResult;
+        BinnedED PoResult;
+
+        Convolution BiSmearer("aConv");
+        BiSmearer.SetFunction(new Gaussian(bestResult.at("gaus_a_1"),bestResult.at("gaus_a_2")));
+        BiSmearer.SetAxes(axes);
+        BiSmearer.SetTransformationObs(obsSet);
+        BiSmearer.SetDistributionObs(obsSet);
+        BiSmearer.Construct();
+
+        Convolution PoSmearer("bConv");
+        PoSmearer.SetFunction(new Gaussian(bestResult.at("gaus_b_1"),bestResult.at("gaus_b_2")));
+        PoSmearer.SetAxes(axes);
+        PoSmearer.SetTransformationObs(obsSet);
+        PoSmearer.SetDistributionObs(obsSet);
+        PoSmearer.Construct();
+
+        PoResult = PoSmearer( PoHolder );
+        BiResult = BiSmearer( BiHolder );
+
+        BiResult.Scale(bestResult.at("a_mc_norm"));
+        PoResult.Scale(bestResult.at("b_mc_norm"));
+
+        TH1D fakeDataHist;
+        TH1D BiFit;
+        TH1D PoFit;
+        BiFit.Sumw2();
+        PoFit.Sumw2();
+        fakeDataHist = DistTools::ToTH1D(fakeData);
+        BiFit= DistTools::ToTH1D(BiResult);
+        PoFit= DistTools::ToTH1D(PoResult);
+
+        TH1D FullFit("FullFit","",BiFit.GetNbinsX(),BiFit.GetXaxis()->GetXmin(),BiFit.GetXaxis()->GetXmax());
+        FullFit.Sumw2();
+
+        FullFit.Add(&BiFit,&PoFit);
+
+        TLegend* leg =new TLegend(0.8,0.7,1,0.9); 
+        leg->AddEntry(&fakeDataHist,"FakeData","lf"); 
+        leg->AddEntry(&BiFit,"a fit result","lf"); 
+        leg->AddEntry(&PoFit,"b fit result","lf"); 
+
+        TCanvas* diff = new TCanvas("diff","",800,800);
+        diff->cd(); 
+        // -------------- Top panel 
+        gStyle->SetOptStat(kFALSE);  
+        TPad *pad1 = new TPad("pad1","pad1",0,0.3,1,1); 
+        pad1->Draw(); 
+        pad1->SetLogy(1); 
+        pad1->cd(); 
+        pad1->SetGrid(kTRUE); 
+        pad1->SetBottomMargin(0.00); 
+        gPad->RedrawAxis();  
+
+        fakeDataHist.SetTitle("Independent Systematic Fit");
+        fakeDataHist.GetYaxis()->SetTitle(Form("Counts"));
+        fakeDataHist.GetYaxis()->SetTitleOffset(1.5); 
+        fakeDataHist.SetFillColorAlpha(kGreen,0.5); 
+
+        fakeDataHist.Draw(); 
+        FullFit.SetFillColorAlpha(kRed,0.5); 
+        BiFit.SetLineColor(kRed);
+        BiFit.SetLineWidth(3);
+        BiFit.Draw("same e"); 
+        PoFit.SetLineColor(kBlue);
+        PoFit.SetLineWidth(3);
+        PoFit.Draw("same e"); 
+
+        TH1D hist1 =  DistTools::ToTH1D(pdf1);
+        TH1D hist2 =  DistTools::ToTH1D(pdf2);
+        hist1.Scale(4000);
+        hist2.Scale(4000);
+
+        hist1.SetFillColorAlpha(kRed,0.5); 
+        hist1.SetLineWidth(2);
+        hist1.Draw("same");
+        hist2.SetFillColorAlpha(kBlue,0.5); 
+        hist2.SetLineWidth(2);
+        hist2.Draw("same");
+
+        leg->AddEntry(&hist1,"a pdf","lf"); 
+        leg->AddEntry(&hist2,"b pdf","lf"); 
+        leg->Draw(); 
+
+        TPaveText pt(0.7,0.2,1.0,0.6,"NDC");
+        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc_norm"]));
+        pt.AddText(Form("b norm = %.2f",bestResult["b_mc_norm"]));
+        pt.AddText(Form("a conv mean = %.2f",bestResult["gaus_a_1"]));
+        pt.AddText(Form("a conv RMS= %.2f",bestResult["gaus_a_2"]));
+        pt.AddText(Form("b conv mean = %.2f",bestResult["gaus_b_1"]));
+        pt.AddText(Form("b conv RMS = %.2f",bestResult["gaus_b_2"]));
+        pt.SetFillColor(kWhite);
+        pt.SetShadowColor(kWhite);
+        pt.Draw();
+        diff->cd(); 
+
+        // -------------- Bottom panel 
+        TPad *pad2 = new TPad("pad2","pad2",0,0.0,1,0.3); 
+        pad2->SetTopMargin(0.00); 
+        pad2->Draw(); 
+        pad2->cd(); 
+        pad2->SetBottomMargin(0.3); 
+        pad2->SetGrid(kTRUE); 
+        gStyle->SetOptStat(kFALSE);  
+
+        TH1D * fracDiff= diffHist(&fakeDataHist,&FullFit); 
+        fracDiff->SetLineWidth(2); 
+
+        fracDiff->GetXaxis()->SetTitle("axis1"); 
+        fracDiff->GetYaxis()->SetTitle("Fit / Fake Data"); 
+        fracDiff->GetYaxis()->SetTitleOffset(0.5); 
+        fracDiff->GetXaxis()->SetLabelSize(0.1); 
+        fracDiff->GetXaxis()->SetTitleSize(0.1); 
+        fracDiff->GetYaxis()->SetLabelSize(0.1); 
+        fracDiff->GetYaxis()->SetTitleSize(0.1); 
+
+        fracDiff->SetMaximum(2); 
+        fracDiff->SetMinimum(0); 
+        fracDiff->Draw(); 
+
+        diff->Print("systematicFitExample_withGroups.png"); 
+        delete diff;
+    }
+}
+
+void
+function2(){
+
+    Rand::SetSeed(0);
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis1", 0, 50 ,200));
+    ObsSet  obsSet(0);
+
+    // Setting up artificial scale with a scaleFactor = 1.5.
+    Scale* scale = new Scale("scale");
+    scale->SetScaleFactor(1.5);
+    scale->SetAxes(axes);
+    scale->SetTransformationObs(obsSet);
+    scale->SetDistributionObs(obsSet);
+    scale->Construct();
+
+    Gaussian gaus1(10, 0.65);
+    Gaussian gaus2(25, 0.5);
+
+    BinnedED pdf1("a_mc", DistTools::ToHist(gaus1, axes));
+    BinnedED pdf2("b_mc", DistTools::ToHist(gaus2, axes));
+    BinnedED pdf3 = scale->operator()(pdf1);
+    BinnedED pdf4 = scale->operator()(pdf2);
+
+    pdf1.SetObservables(0);
+    pdf2.SetObservables(0);    
+    pdf3.SetObservables(0);
+    pdf4.SetObservables(0);
+
+    pdf1.Scale(100000);
+    pdf2.Scale(100000);    
+
+    std::vector<BinnedED> dataPdfs;
+    dataPdfs.push_back(pdf3);
+    dataPdfs.push_back(pdf4);
+    padPDFs(dataPdfs);
+
+    BinnedEDGenerator dataGen;
+    dataGen.SetPdfs(dataPdfs);
+    std::vector<double> rates(2,100000);
+    dataGen.SetRates(rates);
+
+    // BinnedED fakeData= dataGen.ExpectedRatesED();
+    // Fluctuate data.
+    BinnedED fakeData= dataGen.PoissonFluctuatedED();
+
+    pdf1.Normalise();
+    pdf2.Normalise();    
+    std::vector<BinnedED> mcPdfs;
+    mcPdfs.push_back(pdf1);
+    mcPdfs.push_back(pdf2);
+
+    padPDFs(mcPdfs);
+
+    // Setting optimisation limits
+    ParameterDict minima;
+    minima["a_mc_norm"] = 10; 
+    minima["b_mc_norm"] = 10; 
+    minima["scaleFactor" ] = 0.1;
+
+    ParameterDict maxima;
+    maxima["a_mc_norm"] = 200000;
+    maxima["b_mc_norm"] = 200000;
+    maxima["scaleFactor" ] = 2.0;    
+
+    // ParameterDict initialval;
+    // Rand rand;
+    // initialval["a_mc_norm"] = rand.UniformRange(minima["a_mc_norm"],maxima["a_mc_norm"]); 
+    // initialval["b_mc_norm"] = rand.UniformRange(minima["b_mc_norm"],maxima["b_mc_norm"]); 
+    // initialval["gaus_a_1" ] = rand.UniformRange(minima["gaus_a_1" ],maxima["gaus_a_1" ]); 
+    // initialval["gaus_a_2" ] = rand.UniformRange(minima["gaus_a_2" ],maxima["gaus_a_2" ]); 
+    // initialval["gaus_b_1" ] = rand.UniformRange(minima["gaus_b_1" ],maxima["gaus_b_1" ]); 
+    // initialval["gaus_b_2" ] = rand.UniformRange(minima["gaus_b_2" ],maxima["gaus_b_2" ]); 
+
+    ParameterDict initialval;
+    initialval["a_mc_norm"] = 90000; 
+    initialval["b_mc_norm"] = 90000; 
+    initialval["scaleFactor"]  = 1;   
+
+    ParameterDict initialerr;
+    initialerr["a_mc_norm"] = 0.1*initialval["a_mc_norm"];
+    initialerr["b_mc_norm"] = 0.1*initialval["b_mc_norm"];
+    initialerr["scaleFactor" ] = 0.1*initialval["scaleFactor"]; 
+
+    //Setting up likelihood.
+    int BuffLow  = 20;
+    int BuffHigh = 20;
+
+    BinnedNLLH lh; 
+    lh.SetBufferAsOverflow(false);
+    lh.SetBuffer(0,BuffLow,BuffHigh);
+    lh.SetDataDist(fakeData); // initialise with the data set
+
+    // Add global systematic. Order in which global systematics are applied is the same as the order in which they are applied.
+    lh.AddSystematic(scale);
+
+    // Add EDs to lh, by default any global systematic are applied.
+    lh.AddDist(mcPdfs.at(0));
+    lh.AddDist(mcPdfs.at(1));
+
+    Minuit min;
+    min.SetMethod("Simplex");
+    min.SetMaxCalls(10000000);
+    min.SetMinima(minima);
+    min.SetMaxima(maxima);
+    min.SetInitialValues(initialval);
+    min.SetInitialErrors(initialerr);
+
+    std::cout << "function2 : About to Fit" << std::endl;
+    FitResult result = min.Optimise(&lh);
+    result.SetPrintPrecision(4);
+    result.Print();
+    ParameterDict bestResult = result.GetBestFit();
+
+    // Plot Result
+    {
+        BinnedED BiHolder = mcPdfs.at(0);
+        BinnedED PoHolder = mcPdfs.at(1);
+        BinnedED BiResult;
+        BinnedED PoResult;
+
+        Scale* scale = new Scale("scale");
+        scale->SetScaleFactor(bestResult.at("scaleFactor"));
+        scale->SetAxes(axes);
+        scale->SetTransformationObs(obsSet);
+        scale->SetDistributionObs(obsSet);
+        scale->Construct();
+
+        PoResult = scale->operator()( PoHolder );
+        BiResult = scale->operator()( BiHolder );
+
+        BiResult.Scale(bestResult.at("a_mc_norm"));
+        PoResult.Scale(bestResult.at("b_mc_norm"));
+
+        TH1D fakeDataHist;
+        TH1D BiFit;
+        TH1D PoFit;
+        BiFit.Sumw2();
+        PoFit.Sumw2();
+        fakeDataHist = DistTools::ToTH1D(fakeData);
+        BiFit= DistTools::ToTH1D(BiResult);
+        PoFit= DistTools::ToTH1D(PoResult);
+
+        TH1D FullFit("FullFit","",BiFit.GetNbinsX(),BiFit.GetXaxis()->GetXmin(),BiFit.GetXaxis()->GetXmax());
+        FullFit.Sumw2();
+
+        FullFit.Add(&BiFit,&PoFit);
+
+        TLegend* leg =new TLegend(0.8,0.7,1,0.9); 
+        leg->AddEntry(&fakeDataHist,"FakeData","lf"); 
+        leg->AddEntry(&BiFit,"a fit result","lf"); 
+        leg->AddEntry(&PoFit,"b fit result","lf"); 
+
+        TCanvas* diff = new TCanvas("diff","",800,800);
+        diff->cd(); 
+        // -------------- Top panel 
+        gStyle->SetOptStat(kFALSE);  
+        TPad *pad1 = new TPad("pad1","pad1",0,0.3,1,1); 
+        pad1->Draw(); 
+        pad1->SetLogy(1); 
+        pad1->cd(); 
+        pad1->SetGrid(kTRUE); 
+        pad1->SetBottomMargin(0.00); 
+        gPad->RedrawAxis();  
+
+        fakeDataHist.SetTitle("Independent Systematic Fit");
+        fakeDataHist.GetYaxis()->SetTitle(Form("Counts"));
+        fakeDataHist.GetYaxis()->SetTitleOffset(1.5); 
+        fakeDataHist.SetFillColorAlpha(kGreen,0.5); 
+
+        fakeDataHist.Draw(); 
+        FullFit.SetFillColorAlpha(kRed,0.5); 
+        BiFit.SetLineColor(kRed);
+        BiFit.SetLineWidth(3);
+        BiFit.Draw("same e"); 
+        PoFit.SetLineColor(kBlue);
+        PoFit.SetLineWidth(3);
+        PoFit.Draw("same e"); 
+
+        TH1D hist1 =  DistTools::ToTH1D(pdf1);
+        TH1D hist2 =  DistTools::ToTH1D(pdf2);
+        hist1.Scale(4000);
+        hist2.Scale(4000);
+
+        hist1.SetFillColorAlpha(kRed,0.5); 
+        hist1.SetLineWidth(2);
+        hist1.Draw("same");
+        hist2.SetFillColorAlpha(kBlue,0.5); 
+        hist2.SetLineWidth(2);
+        hist2.Draw("same");
+
+        leg->AddEntry(&hist1,"a pdf","lf"); 
+        leg->AddEntry(&hist2,"b pdf","lf"); 
+        leg->Draw(); 
+
+        TPaveText pt(0.7,0.2,1.0,0.6,"NDC");
+        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc_norm"]));
+        pt.AddText(Form("b norm = %.2f",bestResult["b_mc_norm"]));
+        pt.AddText(Form("scaleFactor = %.2f",bestResult["scaleFactor"]));
+        pt.SetFillColor(kWhite);
+        pt.SetShadowColor(kWhite);
+        pt.Draw();
+        diff->cd(); 
+
+        // -------------- Bottom panel 
+        TPad *pad2 = new TPad("pad2","pad2",0,0.0,1,0.3); 
+        pad2->SetTopMargin(0.00); 
+        pad2->Draw(); 
+        pad2->cd(); 
+        pad2->SetBottomMargin(0.3); 
+        pad2->SetGrid(kTRUE); 
+        gStyle->SetOptStat(kFALSE);  
+
+        TH1D * fracDiff= diffHist(&fakeDataHist,&FullFit); 
+        fracDiff->SetLineWidth(2); 
+
+        fracDiff->GetXaxis()->SetTitle("axis1"); 
+        fracDiff->GetYaxis()->SetTitle("Fit / Fake Data"); 
+        fracDiff->GetYaxis()->SetTitleOffset(0.5); 
+        fracDiff->GetXaxis()->SetLabelSize(0.1); 
+        fracDiff->GetXaxis()->SetTitleSize(0.1); 
+        fracDiff->GetYaxis()->SetLabelSize(0.1); 
+        fracDiff->GetYaxis()->SetTitleSize(0.1); 
+
+        fracDiff->SetMaximum(2); 
+        fracDiff->SetMinimum(0); 
+        fracDiff->Draw(); 
+
+        diff->Print("systematicFitExample_noGroup.png"); 
+        delete diff;
+    }
+}
+
+void
+function3(){
+
+    Rand::SetSeed(0);
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis1", 0, 75 ,300));
+    ObsSet  obsSet(0);
+
+    Gaussian gaus1(10, 0.5);
+    Gaussian gaus2(25, 1);
+
+    // Setting up artificial scale with a scaleFactor = 1.5.
+    Scale* scale = new Scale("scale");
+    scale->SetScaleFactor(1.5);
+    scale->SetAxes(axes);
+    scale->SetTransformationObs(obsSet);
+    scale->SetDistributionObs(obsSet);
+    scale->Construct();
+
+    // Setting up artificial convolution with a mean = 0 and std = 1.
+    Convolution* conv_a = new Convolution("conv_a");
+    Gaussian* gaus_a = new Gaussian(0,1,"gaus_a"); 
+    gaus_a->RenameParameter("means_0","gaus_a_1");
+    gaus_a->RenameParameter("stddevs_0","gaus_a_2");
+
+    conv_a->SetFunction(gaus_a);
+    conv_a->SetAxes(axes);
+    conv_a->SetTransformationObs(obsSet);
+    conv_a->SetDistributionObs(obsSet);
+    conv_a->Construct();
+
+    // Setting up artificial convolution with a mean = 0 and std = 2.
+    Convolution* conv_b = new Convolution("conv_b");
+    Gaussian * gaus_b = new Gaussian(0,2,"gaus_b"); 
+    gaus_b->RenameParameter("means_0","gaus_b_1");
+    gaus_b->RenameParameter("stddevs_0","gaus_b_2");
+    conv_b->SetFunction(gaus_b);
+    conv_b->SetAxes(axes);
+    conv_b->SetTransformationObs(obsSet);
+    conv_b->SetDistributionObs(obsSet);
+    conv_b->Construct();
+
+    // Making PDFs. 
+    BinnedED pdf1("a_mc", DistTools::ToHist(gaus1, axes));
+    BinnedED pdf2("b_mc", DistTools::ToHist(gaus2, axes));
+
+    // Making fake data. 
+    // Order of the systematics is important and should be the same order as
+    // added to the likelihood.
+    BinnedED pdf3 = conv_a->operator()(scale->operator()(pdf1));
+    BinnedED pdf4 = conv_b->operator()(scale->operator()(pdf2));
+
+    pdf1.SetObservables(0);
+    pdf2.SetObservables(0);    
+    pdf3.SetObservables(0);
+    pdf4.SetObservables(0);
+
+    pdf1.Scale(100000);
+    pdf2.Scale(100000);    
+
+    std::vector<BinnedED> dataPdfs;
+    dataPdfs.push_back(pdf3);
+    dataPdfs.push_back(pdf4);
+    padPDFs(dataPdfs);
+
+    BinnedEDGenerator dataGen;
+    dataGen.SetPdfs(dataPdfs);
+    std::vector<double> rates(2,100000);
+    dataGen.SetRates(rates);
+
+    // BinnedED fakeData= dataGen.ExpectedRatesED();
+    // Fluctuate data.
+    BinnedED fakeData= dataGen.PoissonFluctuatedED();
+
+    pdf1.Normalise();
+    pdf2.Normalise();    
+    std::vector<BinnedED> mcPdfs;
+    mcPdfs.push_back(pdf1);
+    mcPdfs.push_back(pdf2);
+
+    padPDFs(mcPdfs);
+
+    // Setting optimisation limits
+    ParameterDict minima;
+    minima["a_mc_norm"] = 10; 
+    minima["b_mc_norm"] = 10; 
+    minima["scaleFactor" ] = 0.1;
+    minima["gaus_a_1" ] = -5;
+    minima["gaus_a_2" ] = 0;  
+    minima["gaus_b_1" ] = -5;
+    minima["gaus_b_2" ] = 0;  
+
+    ParameterDict maxima;
+    maxima["a_mc_norm"] = 200000;
+    maxima["b_mc_norm"] = 200000;
+    maxima["scaleFactor" ] = 2.0;    
+    maxima["gaus_a_1" ] = 5;    
+    maxima["gaus_a_2" ] = 5;     
+    maxima["gaus_b_1" ] = 5.;   
+    maxima["gaus_b_2" ] = 5;     
+
+    // ParameterDict initialval;
+    // Rand rand;
+    // initialval["a_mc_norm"] = rand.UniformRange(minima["a_mc_norm"],maxima["a_mc_norm"]); 
+    // initialval["b_mc_norm"] = rand.UniformRange(minima["b_mc_norm"],maxima["b_mc_norm"]); 
+    // initialval["gaus_a_1" ] = rand.UniformRange(minima["gaus_a_1" ],maxima["gaus_a_1" ]); 
+    // initialval["gaus_a_2" ] = rand.UniformRange(minima["gaus_a_2" ],maxima["gaus_a_2" ]); 
+    // initialval["gaus_b_1" ] = rand.UniformRange(minima["gaus_b_1" ],maxima["gaus_b_1" ]); 
+    // initialval["gaus_b_2" ] = rand.UniformRange(minima["gaus_b_2" ],maxima["gaus_b_2" ]); 
+
+    ParameterDict initialval;
+    initialval["a_mc_norm"] = 90000; 
+    initialval["b_mc_norm"] = 90000; 
+    initialval["scaleFactor"]  = 1.4;   
+    initialval["gaus_a_1"]  = 0.;   
+    initialval["gaus_a_2"]  = 1;    
+    initialval["gaus_b_1"]  = 0.;    
+    initialval["gaus_b_2"]  = 2;    
+
+    ParameterDict initialerr;
+    initialerr["a_mc_norm"] = 0.1*initialval["a_mc_norm"];
+    initialerr["b_mc_norm"] = 0.1*initialval["b_mc_norm"];
+    initialerr["scaleFactor" ] = 0.1*initialval["scaleFactor"]; 
+    initialerr["gaus_a_1" ] = 0.1*initialval["gaus_a_1"]; 
+    initialerr["gaus_a_2" ] = 0.1*initialval["gaus_a_2"]; 
+    initialerr["gaus_b_1" ] = 0.1*initialval["gaus_b_1"]; 
+    initialerr["gaus_b_2" ] = 0.1*initialval["gaus_b_2"]; 
+
+    //Setting up likelihood.
+    int BuffLow  = 20;
+    int BuffHigh = 20;
+
+    BinnedNLLH lh; 
+    lh.SetBufferAsOverflow(false);
+    lh.SetBuffer(0,BuffLow,BuffHigh);
+    lh.SetDataDist(fakeData); // initialise with the data set
+
+    // Add the scale as a global systematic.
+    // i.e. The scale is the first systematic applied to all distributions. 
+    // In general global systematics are applied (in the order they are added)
+    // before any other group systematics.
+    lh.AddSystematic(scale);
+    // Adding systematics to groups. The order in which the systematics are
+    // added to the group is the same as the order there are applied.
+    lh.AddSystematic(conv_a,"aGroup");
+    lh.AddSystematic(conv_b,"bGroup");
+
+    // Associate EDs with a vector of groups. The order of the vector dictates
+    // the order in which (multiple) groups are applied. 
+    lh.AddDist(mcPdfs.at(0),std::vector<std::string>(1,"aGroup"));
+    lh.AddDist(mcPdfs.at(1),std::vector<std::string>(1,"bGroup"));
+
+    Minuit min;
+    min.SetMethod("Simplex");
+    min.SetMaxCalls(10000000);
+    min.SetMinima(minima);
+    min.SetMaxima(maxima);
+    min.SetInitialValues(initialval);
+    min.SetInitialErrors(initialerr);
+
+    std::cout << "function3 : About to Fit" << std::endl;
+    FitResult result = min.Optimise(&lh);
+    result.SetPrintPrecision(4);
+    result.Print();
+    ParameterDict bestResult = result.GetBestFit();
+
+    // Plot Result
+    {
+        BinnedED BiHolder = mcPdfs.at(0);
+        BinnedED PoHolder = mcPdfs.at(1);
+        BinnedED BiResult;
+        BinnedED PoResult;
+
+        Scale* scale = new Scale("scale");
+        scale->SetScaleFactor(bestResult.at("scaleFactor"));
+        scale->SetAxes(axes);
+        scale->SetTransformationObs(obsSet);
+        scale->SetDistributionObs(obsSet);
+        scale->Construct();
+
+        Convolution BiSmearer("aConv");
+        BiSmearer.SetFunction(new Gaussian(bestResult.at("gaus_a_1"),bestResult.at("gaus_a_2")));
+        BiSmearer.SetAxes(axes);
+        BiSmearer.SetTransformationObs(obsSet);
+        BiSmearer.SetDistributionObs(obsSet);
+        BiSmearer.Construct();
+
+        Convolution PoSmearer("bConv");
+        PoSmearer.SetFunction(new Gaussian(bestResult.at("gaus_b_1"),bestResult.at("gaus_b_2")));
+        PoSmearer.SetAxes(axes);
+        PoSmearer.SetTransformationObs(obsSet);
+        PoSmearer.SetDistributionObs(obsSet);
+        PoSmearer.Construct();
+
+        BiResult = BiSmearer(scale->operator()( BiHolder ));
+        PoResult = PoSmearer(scale->operator()( PoHolder ));
+
+        BiResult.Scale(bestResult.at("a_mc_norm"));
+        PoResult.Scale(bestResult.at("b_mc_norm"));
+
+        TH1D fakeDataHist;
+        TH1D BiFit;
+        TH1D PoFit;
+        BiFit.Sumw2();
+        PoFit.Sumw2();
+        fakeDataHist = DistTools::ToTH1D(fakeData);
+        BiFit= DistTools::ToTH1D(BiResult);
+        PoFit= DistTools::ToTH1D(PoResult);
+
+        TH1D FullFit("FullFit","",BiFit.GetNbinsX(),BiFit.GetXaxis()->GetXmin(),BiFit.GetXaxis()->GetXmax());
+        FullFit.Sumw2();
+
+        FullFit.Add(&BiFit,&PoFit);
+
+        TLegend* leg =new TLegend(0.8,0.7,1,0.9); 
+        leg->AddEntry(&fakeDataHist,"FakeData","lf"); 
+        leg->AddEntry(&BiFit,"a fit result","lf"); 
+        leg->AddEntry(&PoFit,"b fit result","lf"); 
+
+        TCanvas* diff = new TCanvas("diff","",800,800);
+        diff->cd(); 
+        // -------------- Top panel 
+        gStyle->SetOptStat(kFALSE);  
+        TPad *pad1 = new TPad("pad1","pad1",0,0.3,1,1); 
+        pad1->Draw(); 
+        pad1->SetLogy(1); 
+        pad1->cd(); 
+        pad1->SetGrid(kTRUE); 
+        pad1->SetBottomMargin(0.00); 
+        gPad->RedrawAxis();  
+
+        fakeDataHist.SetTitle("Independent Systematic Fit");
+        fakeDataHist.GetYaxis()->SetTitle(Form("Counts"));
+        fakeDataHist.GetYaxis()->SetTitleOffset(1.5); 
+        fakeDataHist.SetFillColorAlpha(kGreen,0.5); 
+
+        fakeDataHist.Draw(); 
+        FullFit.SetFillColorAlpha(kRed,0.5); 
+        BiFit.SetLineColor(kRed);
+        BiFit.SetLineWidth(3);
+        BiFit.Draw("same e"); 
+        PoFit.SetLineColor(kBlue);
+        PoFit.SetLineWidth(3);
+        PoFit.Draw("same e"); 
+
+        TH1D hist1 =  DistTools::ToTH1D(pdf1);
+        TH1D hist2 =  DistTools::ToTH1D(pdf2);
+        hist1.Scale(4000);
+        hist2.Scale(4000);
+
+        hist1.SetFillColorAlpha(kRed,0.5); 
+        hist1.SetLineWidth(2);
+        hist1.Draw("same");
+        hist2.SetFillColorAlpha(kBlue,0.5); 
+        hist2.SetLineWidth(2);
+        hist2.Draw("same");
+
+        leg->AddEntry(&hist1,"a pdf","lf"); 
+        leg->AddEntry(&hist2,"b pdf","lf"); 
+        leg->Draw(); 
+
+        TPaveText pt(0.7,0.2,1.0,0.7,"NDC");
+        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc_norm"]));
+        pt.AddText(Form("b norm = %.2f",bestResult["b_mc_norm"]));
+        pt.AddText(Form("scaleFactor = %.2f",bestResult["scaleFactor"]));
+        pt.AddText(Form("a conv mean = %.2f",bestResult["gaus_a_1"]));
+        pt.AddText(Form("a conv RMS= %.2f",bestResult["gaus_a_2"]));
+        pt.AddText(Form("b conv mean = %.2f",bestResult["gaus_b_1"]));
+        pt.AddText(Form("b conv RMS = %.2f",bestResult["gaus_b_2"]));
+        pt.SetFillColor(kWhite);
+        pt.SetShadowColor(kWhite);
+        pt.Draw();
+        diff->cd(); 
+
+        // -------------- Bottom panel 
+        TPad *pad2 = new TPad("pad2","pad2",0,0.0,1,0.3); 
+        pad2->SetTopMargin(0.00); 
+        pad2->Draw(); 
+        pad2->cd(); 
+        pad2->SetBottomMargin(0.3); 
+        pad2->SetGrid(kTRUE); 
+        gStyle->SetOptStat(kFALSE);  
+
+        TH1D * fracDiff= diffHist(&fakeDataHist,&FullFit); 
+        fracDiff->SetLineWidth(2); 
+
+        fracDiff->GetXaxis()->SetTitle("axis1"); 
+        fracDiff->GetYaxis()->SetTitle("Fit / Fake Data"); 
+        fracDiff->GetYaxis()->SetTitleOffset(0.5); 
+        fracDiff->GetXaxis()->SetLabelSize(0.1); 
+        fracDiff->GetXaxis()->SetTitleSize(0.1); 
+        fracDiff->GetYaxis()->SetLabelSize(0.1); 
+        fracDiff->GetYaxis()->SetTitleSize(0.1); 
+
+        fracDiff->SetMaximum(2); 
+        fracDiff->SetMinimum(0); 
+        fracDiff->Draw(); 
+
+        diff->Print("systematicFitExample_combined.png"); 
+        delete diff;
+    }
+}
+
+TH1D*
+diffHist(TH1D * h1,TH1D * h2){
+    double minBin=h1->GetXaxis()->GetXmin();
+    double maxBin=h1->GetXaxis()->GetXmax();
+    double numOfBins=h1->GetNbinsX();
+
+    TH1D* rhist = new TH1D("rhist","",numOfBins,minBin,maxBin);
+    for(double i=0;i<numOfBins;i++){
+        double h1cont=h1->GetBinContent(i);
+        double h2cont=h2->GetBinContent(i);
+        double weight;
+        double error;
+        if (h1cont!=0 && h1cont-h2cont!=0) {
+            weight= h2cont/h1cont;
+            error= weight * sqrt(1/sqrt(h2cont) + 1/sqrt(h1cont));
+        } else {
+            // How else do you fix this?
+            weight= 10000000;
+            error = 0;
+        }
+        rhist->SetBinContent(i,weight);
+        rhist->SetBinError(i,error);
+    }
+    return rhist;
+}
+
+void
+padPDFs(std::vector<BinnedED>& binnedEDList){
+    std::cout<<"Padding Now"<<std::endl;
+    for(int i=0;i<binnedEDList.size();i++){
+        std::vector<double> bincontent =binnedEDList.at(i).GetBinContents();
+        std::vector<double> new_bincontent;
+        for(int j =0; j<bincontent.size();j++){
+            if(bincontent.at(j)==0)
+                new_bincontent.push_back(std::numeric_limits< double >::min());
+            else
+                new_bincontent.push_back(bincontent[j]);
+        }
+        binnedEDList[i].SetBinContents(new_bincontent);
+    }
+}

--- a/src/core/SparseMatrix.cpp
+++ b/src/core/SparseMatrix.cpp
@@ -62,6 +62,12 @@ SparseMatrix::operator*=(const SparseMatrix& other_){
   return *this;
 }
 
+SparseMatrix
+SparseMatrix::operator*(const SparseMatrix& other_){
+  fArmaMat = fArmaMat * other_.fArmaMat;
+  return *this;
+}
+
 void
 SparseMatrix::SetZeros(){
     if(!fNRows || !fNCols)

--- a/src/core/SparseMatrix.h
+++ b/src/core/SparseMatrix.h
@@ -27,6 +27,7 @@ class SparseMatrix{
                        const std::vector<double>& values_);
 
     SparseMatrix operator*=(const SparseMatrix& other_);
+    SparseMatrix operator*(const SparseMatrix& other_);
     size_t GetNRows() const {return fNRows;}
     size_t GetNCols() const {return fNCols;}
     void   SetZeros();

--- a/src/fitutil/BinnedEDManager.cpp
+++ b/src/fitutil/BinnedEDManager.cpp
@@ -32,7 +32,6 @@ BinnedEDManager::BinProbability(size_t bin_) const{
     try{
         for(size_t i = 0; i < fWorkingPdfs.size(); i++){
             sum += fNormalisations.at(i) * fWorkingPdfs.at(i).GetBinContent(bin_);
-    
         }
     }
     catch(const std::out_of_range&){
@@ -53,14 +52,11 @@ void
 BinnedEDManager::ApplySystematics(const SystematicManager& sysMan_){
     // If there are no systematics dont do anything
     //  ( working pdfs = original pdfs from initialisation)
-    
-    if(!sysMan_.GetSystematics().size())
+
+    if(!sysMan_.GetSystematicsGroup().size())
         return;
 
-    for(size_t j = 0; j < fOriginalPdfs.size(); j++){
-        fWorkingPdfs[j] = fOriginalPdfs.at(j);
-        fWorkingPdfs[j].SetBinContents(sysMan_.GetTotalResponse().operator()(fOriginalPdfs.at(j).GetBinContents()));
-    }
+    sysMan_.DistortEDs(fOriginalPdfs,fWorkingPdfs);
 }
 
 const BinnedED&

--- a/src/fitutil/SystematicManager.cpp
+++ b/src/fitutil/SystematicManager.cpp
@@ -1,39 +1,276 @@
 #include <SystematicManager.h>
+#include <Exceptions.h>
+#include <Formatter.hpp>
+#include <ContainerTools.hpp>
 
-const std::vector<Systematic*>& 
-SystematicManager::GetSystematics() const{
-    return fSystematics;
-}
+using ContainerTools::GetKeys;
+using ContainerTools::GetValues;
 
 void
 SystematicManager::Construct(){
-    // Dont do anything if there are no systematics
-    if(!fSystematics.size())
+    // Don't do anything if there are no systematics
+    if(!fGroups.size())
         return;
 
-    // construct the response matricies
-    for(size_t i = 0; i < fSystematics.size(); i++)
-        fSystematics[i] -> Construct();
+    //Construct the response matrices.
+    for (std::map<std::string,std::vector<Systematic*> >::const_iterator group=fGroups.begin(); group!= fGroups.end(); ++group ) {
+        //If "" is empty get on with it.
+        if( group->first=="" && group->second.size() ==0 )
+            continue;
+        for(size_t i = 0; i < group->second.size(); i++)
+            fGroups[group->first].at(i) -> Construct();
+    }
 
-    
-    // Assemble the overall response
-    fTotalResponse = fSystematics.at(0) -> GetResponse();
-    for(size_t i = 1; i < fSystematics.size(); i++)
-      fTotalResponse *= fSystematics.at(i) -> GetResponse();
+    //This loop should construct all fGroups.
+    for (std::map<std::string,std::vector<Systematic*> >::const_iterator group =fGroups.begin(); group != fGroups.end(); ++group ) {
+        //If "" is empty get on with it.
+        if( group->first=="" && group->second.size() ==0 )
+            continue;
+
+        SparseMatrix resp = fGroups[group->first].at(0) -> GetResponse();
+        for(size_t i = 1; i < group->second.size(); i++){
+            SparseMatrix holder = fGroups[group->first].at(i)->GetResponse();
+            resp = holder * resp;
+        }
+        fTotalReponses[group->first]=resp;
+    }
 }
 
 const SparseMatrix&
-SystematicManager::GetTotalResponse() const{
-     return fTotalResponse;
-}
-                                        
-void 
-SystematicManager::Add(Systematic* systematic_){    
-    fSystematics.push_back(systematic_);
-    fNSystematics++;
+SystematicManager::GetTotalResponse(const std::string& groupName_) const{
+    //should you construct?
+    try{
+        return fTotalReponses.at(groupName_);
+    }
+    catch(const std::out_of_range& e_){
+        throw NotFoundError(Formatter()<<
+                "SystematicManager :: name : "<< groupName_<<
+                " not found in systematic map");
+    }
 }
 
-size_t
+void
+SystematicManager::Add(Systematic* sys_, const std::string& groupName_){
+    if(groupName_ =="")
+        throw LogicError(Formatter()<<"SystematicManager:: The group name \"\" is reserved and may not be used");
+    fGroups[groupName_].push_back(sys_);
+    fNGroups = fGroups.size();
+}
+
+void
+SystematicManager::Add(Systematic* sys_){
+    checkAllOtherGroups(sys_);
+    fGroups[""].push_back(sys_);
+    fNGroups = fGroups.size();
+}
+
+void
+SystematicManager::checkAllOtherGroups(const Systematic* syss_){
+  std::set<std::string> allname;
+  allname.insert(syss_->GetName());
+  for (int j = 0; j <fGroups.at("").size(); ++j) {
+      if(allname.find( fGroups.at("").at(j)->GetName() ) == allname.end())
+          allname.insert(fGroups.at("").at(j)->GetName());
+      else
+          throw NotFoundError(Formatter()<<
+                  "SystematicManager :: Systematic: "<< 
+                  fGroups.at("").at(j)->GetName()<<
+                  " is in the global systematic group more than once.");
+  } 
+  for (std::map<std::string, std::vector<Systematic*> >::const_iterator i = fGroups.begin(); i != fGroups.end(); ++i) {
+    if( i->first == "")
+      continue;
+    for (std::vector<Systematic*>::const_iterator sys = i->second.begin(); sys != i->second.end(); ++sys) {
+      if(allname.find( (*sys)->GetName() ) == allname.end()){
+        allname.insert( (*sys)->GetName() );
+      }
+      else
+        throw NotFoundError(Formatter()<<
+            "SystematicManager :: Systematic: "<< 
+            (*sys)->GetName()<<
+            " is in the another group and therefore can't be added to the global systematics.");
+    }
+  }
+}
+
+void
+SystematicManager::UniqueSystematics(const std::vector<std::string>& syss_){
+    std::set<std::string> allname;
+    for (int i = 0; i <syss_.size(); ++i) {
+        if(fGroups.find( syss_.at(i) ) == fGroups.end())
+            throw NotFoundError (
+                    Formatter()<<"SystematicManager:: Systematic group "<<
+                    syss_.at(i)<<
+                    "  is not known to the SystematicManager." );
+        std::vector<Systematic*> group = fGroups[syss_.at(i)];
+        for (int j = 0; j < group.size(); ++j) {
+            if(allname.find( group.at(j)->GetName() ) == allname.end())
+                allname.insert(group.at(j)->GetName());
+            else
+                throw NotFoundError(Formatter()<<
+                        "SystematicManager :: Systematic: "<< 
+                        group.at(i)->GetName()<<
+                        " is in more than one group.");
+        } 
+    }
+    // Check the "" group only after everything else has been checked and
+    // allnames has been populated.
+    if( syss_ != std::vector<std::string>(1,"")){
+      std::vector<Systematic*> group = fGroups[""];
+      for (int j = 0; j < group.size(); ++j) {
+        if(allname.find( group.at(j)->GetName() ) == allname.end())
+          allname.insert(group.at(j)->GetName());
+        else
+          throw NotFoundError(Formatter()<<
+              "SystematicManager :: Systematic: "<< 
+              group.at(j)->GetName()<<
+              " is in the global (\"\") group, and therefore would be applied twice.");
+      } 
+    }
+}
+
+void
+SystematicManager::AddDist(const BinnedED& pdf, const std::vector<std::string>& syss_){
+    // Check whether all systematics in syss_ are unique.
+    UniqueSystematics(syss_);
+    fEDGroups[pdf.GetName()] = syss_;
+}
+void
+SystematicManager::AddDist(const BinnedED& pdf, const std::string& syss_){
+    AddDist(pdf,std::vector<std::string>(1,syss_));
+}
+
+void
+SystematicManager::DistortEDs(std::vector<BinnedED>& OrignalEDs_,std::vector<BinnedED>& WorkingEDs_) const {
+    for(size_t j = 0; j < WorkingEDs_.size(); j++){
+        const std::string name = OrignalEDs_.at(j).GetName();
+
+        if(fEDGroups.find(name) == fEDGroups.end())
+            continue;
+
+        //Apply everything else.
+        for (int i = 0; i < fEDGroups.at(name).size(); ++i) {
+            //Check that the group has systematics in it. 
+            std::string groupName = fEDGroups.at(name).at(i);
+            //If "" is empty the do nothing.
+            if( groupName =="" && fGroups.at("").size() == 0 ) {
+                WorkingEDs_[j] = OrignalEDs_.at(j);
+                continue;
+            }
+            if (!fGroups.at( groupName ).size())
+                throw LogicError(Formatter()<<"SystematicManager:: ED "<<
+                        name
+                        <<" has a systematic group of zero size acting on it");
+            // Copy EDs because WorkingED_s have to have the same binning as OrignalEDs_s.
+            WorkingEDs_[j] = OrignalEDs_.at(j);
+            
+            // Logic overview:
+            //    - Check whether fGroups has more that just the "" group in it. If
+            //      not then apply the group as you would expect.
+            //    - If groups have been added but there is nothing in "" then apply
+            //      the groups on their own.
+            //    - Else apply the "" group first and then apply the rest.
+
+            if( fGroups.size() >1 ){
+              if ( fGroups.at("").size() == 0 ){
+                WorkingEDs_[j].SetBinContents(GetTotalResponse(groupName).operator()(OrignalEDs_.at(j).GetBinContents()));
+              } else{
+                WorkingEDs_[j].SetBinContents(
+                    GetTotalResponse(groupName).operator()(
+                      GetTotalResponse("").operator()(OrignalEDs_.at(j).GetBinContents())
+                      )
+                    );
+              }
+            }else{
+              WorkingEDs_[j].SetBinContents(
+                  GetTotalResponse(groupName).operator()(OrignalEDs_.at(j).GetBinContents()));
+            }
+        }
+    }
+}
+
+//Getters and Setters
+
+const size_t
+SystematicManager::GetNSystematicsInGroup(const std::string& name_) const{
+    try{        
+        return fGroups.find(name_)->second.size();
+    }
+    catch(const std::out_of_range& e_){
+        throw NotFoundError(Formatter()<<
+                "SystematicManager :: name : "<< 
+                name_ <<
+                " not known to the SystematicManager.");
+    }
+}
+
+const std::set<std::string>
+SystematicManager::GetGroupNames() const{
+    return GetKeys(fGroups);
+}
+
+const std::vector<std::string>
+SystematicManager::GetSystematicsNamesInGroup(const std::string& name) const{
+    try{
+        std::vector<Systematic*> sys = fGroups.at(name);
+        std::vector<std::string> names;
+        for (int i = 0; i < sys.size(); ++i) {
+            names.push_back(sys.at(i)->GetName());    
+        }
+        return names;
+    }
+    catch(const std::out_of_range& e_){
+        throw NotFoundError(Formatter()<<
+                "SystematicManager :: name : "<< 
+                name <<
+                " not known to the SystematicManager.");
+    }
+
+}
+
+const std::vector<Systematic*>&
+SystematicManager::GetSystematicsInGroup(const std::string& name) const{
+    try{
+        return fGroups.at(name);
+    }catch(const std::out_of_range& e_){
+        throw NotFoundError(Formatter()<<
+                "SystematicManager :: name : "<< 
+                name <<
+                " not known to the SystematicManager.");
+    }
+}
+
+const std::vector<std::string>
+SystematicManager::GetGroup(const std::string& name) const{
+    //Check group exist.
+    if( fGroups.find(name) == fGroups.end())
+        throw NotFoundError(Formatter()<<"SystematicManager:: Group name "<<name<<" not known to the SystematicManager.");
+
+    std::vector<std::string> names;
+    for (std::vector<Systematic*>::const_iterator sys=fGroups.at(name).begin(); sys!= fGroups.at(name).end(); ++sys)
+        names.push_back((*sys)->GetName());
+    return names;
+}
+
+const std::map<std::string, std::vector<Systematic*> >& 
+SystematicManager::GetSystematicsGroup() const{
+    return fGroups;
+}
+
+const size_t
+SystematicManager::CountNSystematics() const{
+    size_t NSystematics = 0;
+    for (std::map<std::string,std::vector<Systematic*> >::const_iterator group =fGroups.begin(); group != fGroups.end(); ++group )
+        NSystematics += group->second.size();
+    return NSystematics;
+}
+
+const size_t
 SystematicManager::GetNSystematics() const{
-    return fNSystematics;
+    return CountNSystematics();
+}
+
+const size_t
+SystematicManager::GetNGroups() const{
+    return fNGroups;
 }

--- a/src/fitutil/SystematicManager.h
+++ b/src/fitutil/SystematicManager.h
@@ -7,25 +7,54 @@
 #ifndef __SYSTEMATIC_MANAGER__
 #define __SYSTEMATIC_MANAGER__
 #include <vector>
+#include <set>
 #include <Systematic.h>
 #include <SparseMatrix.h>
 
 class SystematicManager{
  public:
-    SystematicManager(): fNSystematics(0) {}
+    SystematicManager(){
+      std::vector<Systematic*> holder;
+      fGroups[""]=holder;
+    }
     ~SystematicManager() {}
 
     void Add(Systematic*);
-    const std::vector<Systematic*>& GetSystematics() const;
+
+    void Add(Systematic*,const std::string& groupName_ );
+
+    const std::map<std::string,std::vector<Systematic*> >& GetSystematicsGroup() const;
+
+    const std::vector<Systematic*>& GetSystematicsInGroup(const std::string & name) const;
+
+    const std::set<std::string> GetGroupNames() const;
     
-    size_t GetNSystematics() const;
-    const SparseMatrix& GetTotalResponse() const;
+    const size_t GetNSystematics() const;
+    const size_t GetNGroups() const;
+
+    const size_t GetNSystematicsInGroup(const std::string& name_) const;
+
+    const std::vector<std::string> GetSystematicsNamesInGroup(const std::string& name) const;
+
+    const std::vector<std::string> GetGroup(const std::string& name) const;
+
+    void AddDist(const BinnedED& pdf, const std::vector<std::string>& syss_);
+    void AddDist(const BinnedED& pdf, const std::string& syss_);
+
+    const SparseMatrix& GetTotalResponse(const std::string& groupName_ = "" ) const;
+
+    void DistortEDs(std::vector<BinnedED>& OrigEDs,std::vector<BinnedED>& WorkingEDs) const;
 
     void Construct();
     
  private:
-    std::vector<Systematic*> fSystematics;
-    SparseMatrix fTotalResponse;
-    size_t fNSystematics;
+    size_t fNGroups;
+    std::map<std::string,SparseMatrix> fTotalReponses;
+    std::map<std::string,std::vector<Systematic*> > fGroups;
+
+    std::map<std::string,std::vector<std::string> > fEDGroups;
+    void UniqueSystematics(const std::vector<std::string>&);
+    void checkAllOtherGroups(const Systematic* syss_);
+    const size_t CountNSystematics() const;
 };
 #endif

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -21,10 +21,11 @@ class BinnedNLLH : public TestStatistic{
     void   SetSystematicManager(const SystematicManager&);
 
     void   AddPdf(const BinnedED&);
-    void   AddSystematic(Systematic*);
+    void   AddSystematic(Systematic* sys_);
+    void   AddSystematic(Systematic* sys_, const std::string& group_ );
 
-    void   AddPdfs(const std::vector<BinnedED>&);
     void   AddSystematics(const std::vector<Systematic*>);
+    void   AddSystematics(const std::vector<Systematic*>, const std::vector<std::string>&);
 
     void   SetConstraint(const std::string& paramName_, double mean_, double sigma_);
     
@@ -38,6 +39,12 @@ class BinnedNLLH : public TestStatistic{
 
     void SetDataSet(DataSet*);
     DataSet* GetDataSet();
+
+    void AddDist(const BinnedED& pdf);
+
+    void AddDist(const BinnedED& pdf, const std::vector<std::string>& syss_);
+
+    void AddDist(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& syss_);
 
     void SetBuffer(size_t dim_, unsigned lower_, unsigned upper_);
     std::pair<unsigned, unsigned> GetBuffer(size_t dim_) const;

--- a/src/teststat/ChiSquare.cpp
+++ b/src/teststat/ChiSquare.cpp
@@ -48,8 +48,19 @@ ChiSquare::BinData(){
 void
 ChiSquare::RegisterFitComponents(){
     fComponentManager.AddComponent(&fPdfManager);
-    for(size_t i = 0; i < fSystematicManager.GetSystematics().size(); i++)
-        fComponentManager.AddComponent(fSystematicManager.GetSystematics().at(i));
+
+    //Because the limits are set by name you only need to make sure you add the systematic once.
+    const std::map<std::string, std::vector<Systematic*> > sys_ = fSystematicManager.GetSystematicsGroup();
+    std::vector<std::string> alreadyAdded;
+    for (std::map<std::string, std::vector<Systematic*> >::const_iterator group_ = sys_.begin(); group_ !=sys_.end(); ++group_) {
+        for (int i = 0; i < group_->second.size(); ++i) {
+            if( std::find( alreadyAdded.begin(),alreadyAdded.end(),group_->second.at(i)->GetName() ) == alreadyAdded.end() ){
+                fComponentManager.AddComponent( group_->second.at(i) );
+                alreadyAdded.push_back( group_->second.at(i)->GetName() );
+            }
+        }
+    }
+
 }
 
 

--- a/test/unit/SystematicManagerTest.cpp
+++ b/test/unit/SystematicManagerTest.cpp
@@ -1,0 +1,140 @@
+//The point of this is to test the interace no do a fit.
+#include <catch.hpp>
+#include <BinnedEDManager.h>
+#include <DistTools.h>
+#include <Gaussian.h>
+#include <SystematicManager.h>
+#include <Systematic.h>
+#include <Convolution.h>
+#include <Scale.h>
+#include <iostream>
+#include <ContainerTools.hpp>
+#include <numeric>
+
+class FakeSystematic : public Systematic{
+public:
+    FakeSystematic(const std::string& name_)  {name = name_; }
+    ~FakeSystematic()  {}
+
+    // BinnedED 
+    // operator()(const BinnedED& pdf_) const{;}
+
+    // Don't overload these methods as they are good in Systematic.
+    // void SetResponse(const SparseMatrix& responseMatrix_){resp= responseMatrix_;}
+    // const SparseMatrix& GetResponse() const{return resp;}
+        
+    // void   SetTransformationObs(const ObsSet&){;}
+
+    // ObsSet GetTransformationObs() const{return ObsSet(3);} 
+    //
+    // void   SetDistributionObs(const ObsSet&){;}
+    // ObsSet GetDistributionObs() const{return ObsSet(3);}
+
+    void Construct() {;}
+
+    void   SetParameter(const std::string& name_, double value) {;}
+    double GetParameter(const std::string& name_) const { return 1;}
+
+    void   SetParameters(const ParameterDict&) {;}
+    ParameterDict GetParameters() const {ParameterDict temp;return temp;}
+    size_t GetParameterCount() const  {;}
+
+    std::set<std::string> GetParameterNames() const {std::set<std::string> temp;return temp;}
+    void   RenameParameter(const std::string& old_, const std::string& new_) {;}
+
+    std::string GetName() const {return name;}
+    void SetName(const std::string& name_) {name = name_;}
+private:
+    std::string name;
+};
+
+TEST_CASE("SystematicManager"){
+
+    SparseMatrix id(50,50);
+    id.SetToIdentity();
+    SparseMatrix zero(50,50);
+    zero.SetZeros();
+
+    FakeSystematic sys1("sys1");
+    sys1.SetResponse(id);
+    FakeSystematic sys2("sys2");
+    sys2.SetResponse(zero);
+    FakeSystematic sys3("sys3");
+    sys3.SetResponse(id);
+    FakeSystematic sys4("sys4");
+    sys4.SetResponse(id);
+
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis1", -10, 10 ,50));
+
+    BinnedED pdf1("pdf1",axes);
+    BinnedED pdf2("pdf2",axes);
+
+    pdf1.SetBinContent(10,0.5);
+    pdf1.SetBinContent(40,0.5);
+
+    pdf2.SetBinContent(10,0.5);
+    pdf2.SetBinContent(40,0.5);
+
+    std::vector<BinnedED> pdfs;
+    pdfs.push_back(pdf1);
+    pdfs.push_back(pdf2);
+
+    SystematicManager man;
+
+    man.Add(&sys1);
+    man.Add(&sys4);
+    man.Add(&sys2,"groupName");
+    man.Add(&sys3,"groupName");
+    man.Construct();
+
+    std::vector<std::string> appliedGroups;
+    appliedGroups.push_back("groupName");
+    man.AddDist(pdf2,appliedGroups); 
+
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs,pdfs);
+
+    SECTION("Check number of groups"){
+        REQUIRE(  man.GetNGroups() == 2 );
+    }
+
+    SECTION("Set group names correctly"){
+        std::set<std::string> name =  man.GetGroupNames();
+        REQUIRE( name.find("groupName") != name.end() );
+    }
+
+    SECTION("Counting systematics"){
+        int n =  man.GetNSystematics();
+        REQUIRE( n == 4);
+        n =  man.GetNSystematicsInGroup("");
+        REQUIRE( n == 2);
+        n =  man.GetNSystematicsInGroup("groupName");
+        REQUIRE( n == 2);
+    }
+
+    SECTION("Applying identity does nothing"){
+        REQUIRE( pdfs.at(0).GetBinContent(10) == 0.5 );
+    }
+
+    SECTION("Applying null matrix destroys everything"){
+        std::vector<double> vec= pdfs.at(1).GetBinContents();
+        REQUIRE( std::accumulate(vec.begin(), vec.end(), 0) == 0 );
+    }
+
+    SECTION("Picking up emtpy groups"){
+        bool flag = 0;
+        try {
+            std::vector<std::string> anotherGroup;
+            anotherGroup.push_back("anotherGroup");
+            man.AddDist(pdf2,anotherGroup); 
+            man.DistortEDs(OrignalPdfs, pdfs);
+        }catch(const NotFoundError& e_){
+            flag=1;
+        }
+
+        REQUIRE( flag == 1 );
+    }
+
+}


### PR DESCRIPTION
The SystematicManager now stores its systematics in map of vectors.
Each vector is referred to as a group and is keyed by the name of that
group. Systematics are added to a group through the BinnedNLLH (lh)
like:

    lh.AddSystematic(Systematic, "groupName");

The order in which the systematic is added to a group is the order in
which it is applied. If a group name is not specified, the systematic is
added the global ("") group which is then *always* applied to all EDs
before any other groups.

A ED is then associated with a vector of groups that will be applied to
that ED in that order:

    std::vector<std::string> appliedSys;
    appliedSys.push_back("GroupA");
    appliedSys.push_back("GroupB");
    lh.AddDist(ED,"appliedSys")

Global and group bases systematics may be applied together.

See examples/systematicFit.cpp for example fit.

Other changes

\#\#\# Details

There have been some changes to the to the previous PR.

\#\#\#\#\# Aim \#\#\#\#\#
We want to be able to add systematics to specific groups e.g.
"alphaEnergyRes", which can then be chained to each other and then
associated with a distribution.  However we also want to retain the
previous behaviour of adding global systematics to the lh which then
acts on all distributions. The problem with the previous attempt was
that it could, in some situations, become hard to know which groups were
applied.

To get around this I decided to change things so that in the following
ways:

* The global ("") group is now always created on initialisation and
given that it contains systematics is always applied to all distributions
in the lh.

* This change comes with some required extra logic:
  * When a distribution is added to the lh, the systematics it is
associated with are checked so that they don't apply to same systematic
twice and also checks the "" groups for the same reason.
  * When adding to the "" group the systematic is checked against all
existing groups to make sure that can't be applied twice.
  * In this way it is not possible for systematics to be applied twice.
  * There is then logic to apply the "" group before any other groups
associated with that distribution if it is populated.

* To get the correct ordering when calculating the total response matrix
for a group I changed the operator used. *Problem for anyone using
systematics in their fits*.

* The new scheme doesn't allow for a "group chain" applied to a
distribution to contain the "" group. e.g.
{"alphaEnergyRes","","somethingElse"}. Something like this can easily be
achieved by specifying the groups explicitly.
  * Also the person has to know about the "" group, which can only be
known by looking the code or this commit message. And therefore they are
being too clever for me and deserve everything they get. But honestly I
tried to put that in and it is so hard in this scheme.