### PR TITLE
Address review comments from PR#3 - systematics groups

### DIFF
--- a/examples/simpleFit.cpp
+++ b/examples/simpleFit.cpp
@@ -61,8 +61,8 @@ int main(){
     ROOTNtuple dataNt(dataFile, dataTreeName);
     BinnedNLLH lhFunction;
     lhFunction.SetDataSet(&dataNt); // initialise withe the data set
-    lhFunction.AddDist(bgPdf);        
-    lhFunction.AddDist(signalPdf);        
+    lhFunction.AddPdf(bgPdf);        
+    lhFunction.AddPdf(signalPdf);        
   
     std::cout << "Built LH function " << std::endl;
 

--- a/examples/systematicFit.cpp
+++ b/examples/systematicFit.cpp
@@ -1,3 +1,16 @@
+//////////////////////////////////////////////////////////////////////////////
+// Systematics can be applied either to all distributions in a likelihood   //
+// or only to a group of scpecific distributions, e.g. alpha energy         //
+// resolution. For the former, there is a global ("") group that is always  //
+// present and gets applied before any group systematics. In order to add   //
+// a systematic to this "" group, one can do                                //
+//         lh.AddSystematic(conv,"") or just lh.AddSystematic(conv)         //
+// To add asystematic to a specific group instead use:                      //
+//                     lh.AddSystematic(conv,"groupName")                   //
+//                                                                          //
+// This example demonstartes the use of systematic groups as well as global //
+// systematics and their combination, giving usage examples in each case.   //
+//////////////////////////////////////////////////////////////////////////////
 #include <string>        
 #include <vector>        
 #include <math.h>	
@@ -31,22 +44,22 @@
 TH1D* diffHist(TH1D * h1,TH1D * h2);
 void padPDFs(std::vector<BinnedED>& binnedEDList);
 
-void function1();
-void function2();
-void function3();
+void fitWithSystematicsGroups();
+void fitWithGlobalSystematics();
+void fitWithCombinedSystematics();
 
 int main(int argc, char *argv[]){
     // Using groups of systematics.
-    function1();
+    fitWithSystematicsGroups();
     // Using global of systematics.
-    function2();
+    fitWithGlobalSystematics();
     // Using both global systematics with groups of systematics.
-    function3();
+    fitWithCombinedSystematics();
     return 0;
 }
 
 void
-function1(){
+fitWithSystematicsGroups(){
 
     Rand::SetSeed(0);
     Gaussian gaus1(10, 0.65);
@@ -177,8 +190,8 @@ function1(){
 
     // Associate EDs with a vector of groups. The order of the vector of groups
     // is the same as the order in which they are applied.
-    lh.AddDist(mcPdfs.at(0),std::vector<std::string>(1,"aGroup"));
-    lh.AddDist(mcPdfs.at(1),std::vector<std::string>(1,"bGroup"));
+    lh.AddPdf(mcPdfs.at(0),std::vector<std::string>(1,"aGroup"));
+    lh.AddPdf(mcPdfs.at(1),std::vector<std::string>(1,"bGroup"));
 
     Minuit min;
     min.SetMethod("Simplex");
@@ -188,7 +201,7 @@ function1(){
     min.SetInitialValues(initialval);
     min.SetInitialErrors(initialerr);
 
-    std::cout << "function1 : About to Fit" << std::endl;
+    std::cout << "fitWithSystematicsGroups : About to Fit" << std::endl;
     FitResult result = min.Optimise(&lh);
     result.SetPrintPrecision(4);
     result.Print();
@@ -324,7 +337,7 @@ function1(){
 }
 
 void
-function2(){
+fitWithGlobalSystematics(){
 
     Rand::SetSeed(0);
     AxisCollection axes;
@@ -420,8 +433,8 @@ function2(){
     lh.AddSystematic(scale);
 
     // Add EDs to lh, by default any global systematic are applied.
-    lh.AddDist(mcPdfs.at(0));
-    lh.AddDist(mcPdfs.at(1));
+    lh.AddPdf(mcPdfs.at(0));
+    lh.AddPdf(mcPdfs.at(1));
 
     Minuit min;
     min.SetMethod("Simplex");
@@ -431,7 +444,7 @@ function2(){
     min.SetInitialValues(initialval);
     min.SetInitialErrors(initialerr);
 
-    std::cout << "function2 : About to Fit" << std::endl;
+    std::cout << "fitWithGlobalSystematics : About to Fit" << std::endl;
     FitResult result = min.Optimise(&lh);
     result.SetPrintPrecision(4);
     result.Print();
@@ -557,7 +570,7 @@ function2(){
 }
 
 void
-function3(){
+fitWithCombinedSystematics(){
 
     Rand::SetSeed(0);
     AxisCollection axes;
@@ -705,8 +718,8 @@ function3(){
 
     // Associate EDs with a vector of groups. The order of the vector dictates
     // the order in which (multiple) groups are applied. 
-    lh.AddDist(mcPdfs.at(0),std::vector<std::string>(1,"aGroup"));
-    lh.AddDist(mcPdfs.at(1),std::vector<std::string>(1,"bGroup"));
+    lh.AddPdf(mcPdfs.at(0),std::vector<std::string>(1,"aGroup"));
+    lh.AddPdf(mcPdfs.at(1),std::vector<std::string>(1,"bGroup"));
 
     Minuit min;
     min.SetMethod("Simplex");
@@ -716,7 +729,7 @@ function3(){
     min.SetInitialValues(initialval);
     min.SetInitialErrors(initialerr);
 
-    std::cout << "function3 : About to Fit" << std::endl;
+    std::cout << "fitWithCombinedSystematics : About to Fit" << std::endl;
     FitResult result = min.Optimise(&lh);
     result.SetPrintPrecision(4);
     result.Print();
@@ -889,14 +902,6 @@ void
 padPDFs(std::vector<BinnedED>& binnedEDList){
     std::cout<<"Padding Now"<<std::endl;
     for(int i=0;i<binnedEDList.size();i++){
-        std::vector<double> bincontent =binnedEDList.at(i).GetBinContents();
-        std::vector<double> new_bincontent;
-        for(int j =0; j<bincontent.size();j++){
-            if(bincontent.at(j)==0)
-                new_bincontent.push_back(std::numeric_limits< double >::min());
-            else
-                new_bincontent.push_back(bincontent[j]);
-        }
-        binnedEDList[i].SetBinContents(new_bincontent);
+      binnedEDList.at(i).AddPadding();
     }
 }

--- a/src/dist/BinnedED.cpp
+++ b/src/dist/BinnedED.cpp
@@ -256,3 +256,9 @@ BinnedED::Divide(const BinnedED& other_){
         throw ValueError("BinnedED::Add can't add distributions with different binning definitions!");
     }
 }
+
+
+void
+BinnedED::AddPadding(double padding_){
+  fHistogram.AddPadding(padding_);
+}

--- a/src/dist/BinnedED.h
+++ b/src/dist/BinnedED.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <limits>
 
 class Event;
 class BinnedED : public EventDistribution{
@@ -69,6 +70,8 @@ class BinnedED : public EventDistribution{
 
     std::string GetName() const;
     void SetName(const std::string&);
+
+    void AddPadding(double padding_ = std::numeric_limits<double>::min());
     
  protected:
     ObsSet      fObservables;

--- a/src/fitutil/BinnedEDManager.cpp
+++ b/src/fitutil/BinnedEDManager.cpp
@@ -53,7 +53,7 @@ BinnedEDManager::ApplySystematics(const SystematicManager& sysMan_){
     // If there are no systematics dont do anything
     //  ( working pdfs = original pdfs from initialisation)
 
-    if(!sysMan_.GetSystematicsGroup().size())
+    if(!sysMan_.GetNSystematics())
         return;
 
     sysMan_.DistortEDs(fOriginalPdfs,fWorkingPdfs);

--- a/src/fitutil/SystematicManager.cpp
+++ b/src/fitutil/SystematicManager.cpp
@@ -9,7 +9,7 @@ using ContainerTools::GetValues;
 void
 SystematicManager::Construct(){
     // Don't do anything if there are no systematics
-    if(!fGroups.size())
+    if(!CountNSystematics())
         return;
 
     //Construct the response matrices.
@@ -239,6 +239,13 @@ SystematicManager::GetSystematicsInGroup(const std::string& name) const{
                 " not known to the SystematicManager.");
     }
 }
+
+
+const std::vector<Systematic*>&
+SystematicManager::GetGlobalSystematics() const{
+  return fGroups.at("");
+}
+
 
 const std::vector<std::string>
 SystematicManager::GetGroup(const std::string& name) const{

--- a/src/fitutil/SystematicManager.h
+++ b/src/fitutil/SystematicManager.h
@@ -2,6 +2,11 @@
 /* Manages a set of pdfs, recieves a list of parameters and passes them out to each of the systematics*/
 /* and triggeres their reconstruction. Systematics inside are passed to a set of pdfs to change       */
 /* them                                                                                               */
+/*                                                                                                    */
+/* A group logic is employed, where systematics can be associated with a group of pdfs. A global      */
+/* group ("") is created upon initialisation, which gets applied first to all distributions added.    */
+/* If no group is specified when adding a systematics, it is automatically assigned to this global    */
+/* group.                                                                                             */
 /******************************************************************************************************/
 
 #ifndef __SYSTEMATIC_MANAGER__
@@ -37,6 +42,8 @@ class SystematicManager{
     const std::vector<std::string> GetSystematicsNamesInGroup(const std::string& name) const;
 
     const std::vector<std::string> GetGroup(const std::string& name) const;
+
+    const std::vector<Systematic*>& GetGlobalSystematics() const;
 
     void AddDist(const BinnedED& pdf, const std::vector<std::string>& syss_);
     void AddDist(const BinnedED& pdf, const std::string& syss_);

--- a/src/histogram/Histogram.cpp
+++ b/src/histogram/Histogram.cpp
@@ -254,3 +254,17 @@ std::vector<std::string>
 Histogram::GetAxisNames() const{
     return fAxes.GetAxisNames();
 }
+
+
+void
+Histogram::AddPadding(double padding_){
+  std::vector<double> newBinContents;
+  for(int i =0; i<fBinContents.size();i++){
+    if(fBinContents.at(i)==0)
+      newBinContents.push_back(padding_);
+    else
+      newBinContents.push_back(fBinContents[i]);
+  }  
+  fBinContents = newBinContents;
+
+}

--- a/src/histogram/Histogram.h
+++ b/src/histogram/Histogram.h
@@ -9,6 +9,7 @@
 #include <AxisCollection.h>
 #include <vector>
 #include <map>
+#include <limits>
 
 class Histogram{
  public:
@@ -56,6 +57,8 @@ class Histogram{
     void Divide(const Histogram&);
     
     std::vector<std::string> GetAxisNames() const;
+
+    void AddPadding(double padding_ = std::numeric_limits<double>::min());
     
  private:
     AxisCollection fAxes;

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -21,6 +21,7 @@ BinnedNLLH::Evaluate(){
         fAlreadyShrunk = true;
     }
 
+
     // Construct systematics 
     fSystematicManager.Construct(); 
     // Apply systematics
@@ -62,28 +63,31 @@ BinnedNLLH::BinData(){
 }
 
 void
-BinnedNLLH::AddDist(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& sys_){
+BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& sys_){
     if (pdfs.size() != sys_.size())
        throw DimensionError(Formatter()<<"BinnedNLLH:: #sys_ != #group_");
     for (int i = 0; i < pdfs.size(); ++i)
-        AddDist( pdfs.at(i), sys_.at(i) );
+        AddPdf( pdfs.at(i), sys_.at(i) );
 }
 
 void
-BinnedNLLH::AddDist(const BinnedED& pdf_, const std::vector<std::string>& syss_){
+BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs){
+    for (int i = 0; i < pdfs.size(); ++i)
+        AddPdf(pdfs.at(i));
+}
+
+void
+BinnedNLLH::AddPdf(const BinnedED& pdf_, const std::vector<std::string>& syss_){
     fPdfManager.AddPdf(pdf_);
     fSystematicManager.AddDist(pdf_,syss_);
 }
 
 void
-BinnedNLLH::AddDist(const BinnedED& pdf_){
+BinnedNLLH::AddPdf(const BinnedED& pdf_){
     fPdfManager.AddPdf(pdf_);
     fSystematicManager.AddDist(pdf_,"");
 }
-void
-BinnedNLLH::AddPdf(const BinnedED& pdf_){
-    AddDist(pdf_);
-}
+
 
 void
 BinnedNLLH::SetPdfManager(const BinnedEDManager& man_){

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -40,11 +40,9 @@ class BinnedNLLH : public TestStatistic{
     void SetDataSet(DataSet*);
     DataSet* GetDataSet();
 
-    void AddDist(const BinnedED& pdf);
-
-    void AddDist(const BinnedED& pdf, const std::vector<std::string>& syss_);
-
-    void AddDist(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& syss_);
+    void AddPdf(const BinnedED& pdf, const std::vector<std::string>& syss_);
+    void AddPdfs(const std::vector<BinnedED>& pdfs);
+    void AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& syss_);
 
     void SetBuffer(size_t dim_, unsigned lower_, unsigned upper_);
     std::pair<unsigned, unsigned> GetBuffer(size_t dim_) const;


### PR DESCRIPTION
This deals with the review comments I left on PR #3 .

An overview:
- add description of the systematics group logic to SystematicManager.h
- add function AddPadding to Histogram and BinnedED, so that is can be used by the users as well as the examples and to avoid code repetition - it adds very small numbers to 0 content bins
- move AddDist back to AddPdf and add back AddPds in BinnedNLLH to improve backward compatibility and avoid unnecessary additional methods
- clean up simpleSystematicFit example a little 
- fix logic for when there is no systematics (because now there is always "" group, but can be empty)
- added description and changed function names in systematicFit example

No changes in functionality expected compared to PR3 apart from the simple logic change. Examples produce the same results.