### PR TITLE
Add slices of distributions and two other minor tweaks for HMC

### DIFF
--- a/src/core/Combinations.cpp
+++ b/src/core/Combinations.cpp
@@ -1,0 +1,21 @@
+#include <Combinations.hpp>
+#include <Exceptions.h>
+#include <vector>
+#include <utility>
+#include <assert.h>
+#include <set>
+#include <iostream>
+
+void
+Combinations::RecursiveCombinations(size_t depth, std::vector< std::vector<size_t> >& combs, std::vector<size_t> vec, std::vector<size_t> maxes){
+
+  if (depth>0){
+    for(size_t i=0; i<maxes[depth-1]; i++){
+      vec[depth-1] = i;
+      RecursiveCombinations(depth-1, combs, vec, maxes);
+    }   
+  }else{
+    combs.push_back(vec);
+  }
+  return; 
+}

--- a/src/core/Combinations.hpp
+++ b/src/core/Combinations.hpp
@@ -37,6 +37,7 @@ std::vector<T1> Range(const T1& N, const T1& start = 0){
     return ret;
 }
 
+void RecursiveCombinations(size_t depth, std::vector< std::vector<size_t> >& combs, std::vector<size_t> vec, std::vector<size_t> maxes);
 
 }
 #endif

--- a/src/data/IO.cpp
+++ b/src/data/IO.cpp
@@ -25,13 +25,13 @@ IO::GetExt(const std::string& path_){
 }
 
 void
-IO::SaveDataSet(const DataSet& dataSet_, const std::string& filename_){
+IO::SaveDataSet(const DataSet& dataSet_, const std::string& filename_, const std::string& treename_){
     std::string ext = GetExt(filename_);
     if(ext == "h5")
         SaveDataSetH5(dataSet_, filename_);
 
     else if(ext == "root")
-        SaveDataSetROOT(dataSet_, filename_);
+        SaveDataSetROOT(dataSet_, filename_, treename_);
 
     else
         throw IOError("IO::SaveDataSet Don't know how to save file as ." + ext);
@@ -39,7 +39,7 @@ IO::SaveDataSet(const DataSet& dataSet_, const std::string& filename_){
 
 
 void
-IO::SaveDataSetROOT(const DataSet& dataSet_, const std::string& filename_){
+IO::SaveDataSetROOT(const DataSet& dataSet_, const std::string& filename_, const std::string& treename_){
     // note if this is already a ROOT tree this is a super silly way to do it, but it doesn't make sense to do it
     // anyway
     if(!dataSet_.GetObservableNames().size()){
@@ -54,7 +54,7 @@ IO::SaveDataSetROOT(const DataSet& dataSet_, const std::string& filename_){
     }
 
     TFile f(filename_.c_str(), "RECREATE");
-    TNtuple nt("oxsx_saved", "", branchString.c_str());
+    TNtuple nt(treename_.c_str(), "", branchString.c_str());
 
     int oneTenth = dataSet_.GetNEntries()/10;
     for(size_t i = 0; i < dataSet_.GetNEntries(); i++){

--- a/src/data/IO.h
+++ b/src/data/IO.h
@@ -16,9 +16,9 @@ class Histogram;
 
 class IO{
  public:
-    static void SaveDataSet(const DataSet&, const std::string& filename_);    
+    static void SaveDataSet(const DataSet&, const std::string& filename_, const std::string& = "oxsx_saved");    
     static void SaveDataSetH5(const DataSet&, const std::string& filename_);
-    static void SaveDataSetROOT(const DataSet&, const std::string& filename_);
+    static void SaveDataSetROOT(const DataSet&, const std::string& filename_, const std::string& = "oxsx_saved");
       
 
     static void SaveHistogramH5(const Histogram& , const std::string& filename_);

--- a/src/dist/BinnedED.cpp
+++ b/src/dist/BinnedED.cpp
@@ -218,6 +218,31 @@ BinnedED::Marginalise(const std::string& name_) const{
     return Marginalise(std::vector<std::string>(1, name_));
 }
 
+BinnedED 
+BinnedED::GetSlice(const std::map<std::string, size_t>& namesAndBins_) const{
+    
+    const std::vector<std::string> allAxisNames = fHistogram.GetAxes().GetAxisNames();
+    std::vector<std::string> newObsNames;
+
+    // create a name for the slice and get the observable name
+    Formatter f;
+    f << fName;
+    for(std::vector<std::string>::const_iterator it = allAxisNames.begin(); it!=allAxisNames.end(); it++){
+        if(namesAndBins_.find(*it) == namesAndBins_.end()){
+	    //this is the axis we want the slice in
+	    newObsNames.push_back(*it);
+	}else{
+	    f << "_" << *it << namesAndBins_.at(*it);
+	}
+    }
+    f << "_slice";
+
+    // slice the histogram
+    BinnedED slice(std::string(f), fHistogram.GetSlice(namesAndBins_));
+    slice.SetObservables(newObsNames);
+    return slice;
+}
+
 void
 BinnedED::Add(const BinnedED& other_, double weight){
     if(other_.fObservables != fObservables)

--- a/src/dist/BinnedED.h
+++ b/src/dist/BinnedED.h
@@ -59,7 +59,9 @@ class BinnedED : public EventDistribution{
         
     BinnedED Marginalise(const std::vector<std::string>& indices_) const;
     BinnedED Marginalise(const std::string& index_) const;
-    
+
+    BinnedED GetSlice(const std::map<std::string, size_t>& namesAndBins_) const;
+
     void   SetObservables(const std::vector<std::string>&);
     const std::vector<std::string>& GetObservables() const;
 

--- a/src/eventSystematic/EventShift.cpp
+++ b/src/eventSystematic/EventShift.cpp
@@ -13,7 +13,7 @@ EventShift::operator()(const Event& inEvent_){
     std::string obsToChange = fOutObservables.GetNames().at(0);
     
     // pull out the relevant data point
-    newEvent.SetDatum(obsToChange, inEvent_.GetDatum(obsToChange) * GetShift());
+    newEvent.SetDatum(obsToChange, inEvent_.GetDatum(obsToChange) + GetShift());
     return newEvent;
 }
 

--- a/src/histogram/HistTools.h
+++ b/src/histogram/HistTools.h
@@ -24,6 +24,9 @@ class HistTools{
     // this works for histograms and binnedED -> put it somewhere else
     template<typename T>
     static std::vector<T> GetVisualisableProjections(const T&);
+
+    template<typename T>
+    static std::vector<T> Get1DSlices(const T&, const std::string&);
 };
 
 #include <HistTools.hpp>

--- a/src/histogram/HistTools.hpp
+++ b/src/histogram/HistTools.hpp
@@ -46,3 +46,49 @@ HistTools::GetVisualisableProjections(const T& hist_){
   }
   return hists;
 }
+
+template<typename T>
+std::vector<T>
+HistTools::Get1DSlices(const T& hist_, const std::string& axisName_){
+
+  std::vector<std::string> axisNames = hist_.GetAxes().GetAxisNames();
+  std::vector<std::string> fixedAxisNames;
+  for(std::vector<std::string>::iterator it = axisNames.begin(); it!=axisNames.end(); it++){
+    if ((*it)!=axisName_) fixedAxisNames.push_back(*it);
+  }
+
+  // get no of bins for the corresponding axes
+  std::vector<size_t> maxes;
+  for(std::vector<std::string>::iterator it = fixedAxisNames.begin(); it!=fixedAxisNames.end(); it++){
+    maxes.push_back(hist_.GetAxes().GetAxis(*it).GetNBins());
+  }
+  
+  // reserve space for slice histos
+  std::vector<T> hists;
+  size_t totalNBins = hist_.GetNBins();
+  size_t axisNBins = hist_.GetAxes().GetAxis(axisName_).GetNBins();
+  hists.reserve(totalNBins/axisNBins);
+  
+  // get all combinations of bin indices
+  size_t dim  = hist_.GetNDims();
+  std::vector< std::vector<size_t> > combs;
+  combs.reserve(totalNBins/axisNBins);
+  std::vector<size_t> vec;
+  vec.resize(fixedAxisNames.size());
+  
+  Combinations::RecursiveCombinations(fixedAxisNames.size(), combs, vec, maxes);
+  
+  for(std::vector< std::vector<size_t> >::iterator it = combs.begin(); it!=combs.end(); it++){
+
+    // associate axis names with bin indices for the given combination
+    std::map<std::string, size_t> sliceMap;
+    for(size_t i=0; i<dim-1; i++){
+      sliceMap[fixedAxisNames.at(i)]= (*it).at(i);
+    }
+
+    // get the slice histo
+    T slice = hist_.GetSlice(sliceMap);
+    hists.push_back(slice); 
+  }
+  return hists;
+}

--- a/src/histogram/Histogram.h
+++ b/src/histogram/Histogram.h
@@ -47,6 +47,8 @@ class Histogram{
     Histogram Marginalise(const std::vector<std::string>& indices_) const;
     Histogram Marginalise(const std::string& index_) const;
     
+    Histogram GetSlice(const std::map<std::string, size_t>& fixedBins_) const;
+
     double    GetBinLowEdge(size_t bin_, size_t dim_) const;
     double    GetBinHighEdge(size_t bin_, size_t dim_) const;
     double    GetBinCentre(size_t bin_, size_t dim_) const;


### PR DESCRIPTION
There are 3 commits, not really related to each other, but two are really minor:
- add possibility to name a tree when saving a dataset - this can save some pain if you happen to need them saved with different name, defaults to the old "oxsx_saved", so shouldn't change anything if you don't
- fix bug in EventShift - should definitely be + not *

The bigger one is adding functionality to create slices of BinnedEDs and histograms. This is really useful if you have to look at multiD distributions and projections are just not enough. 
- The new Get1DSlices function in DistTools get all the bin combinations in the requested slice observable. 
- BinnedED::GetSlice gets the name of the slice right and calls the next thing for the corresponding histogram
- Histogram::GetSlice actually gets the slice