### PR TITLE
Fixed unit tests for HMC branch

### DIFF
--- a/src/data/DataSetGenerator.cpp
+++ b/src/data/DataSetGenerator.cpp
@@ -169,7 +169,7 @@ DataSetGenerator::RandomDrawsNoReplacement(size_t handleIndex_, int nEvents_,
     max = eventIndices.size() - 1; // the effective end of the array
   }
 
-  if(nEvents_ >  max)
+  if(nEvents_ > origData -> GetNEntries())
     throw NotFoundError(Formatter() << "DataSetGenerator::RandomDrawsNoReplacement() asked for "
                         << nEvents_ << " but only have " << origData -> GetNEntries() 
                         << "events!)");

--- a/test/unit/BinnedEDManagerTest.cpp
+++ b/test/unit/BinnedEDManagerTest.cpp
@@ -16,9 +16,12 @@ TEST_CASE("Three pdfs no systematics"){
     BinnedED pdf2("b", DistTools::ToHist(gaus2, axes));
     BinnedED pdf3("c", DistTools::ToHist(gaus3, axes));
 
-    pdf1.SetObservables(0);
-    pdf2.SetObservables(0);    
-    pdf3.SetObservables(0);
+    std::vector<std::string> observable;
+    observable.push_back("obs0");
+
+    pdf1.SetObservables(observable);
+    pdf2.SetObservables(observable);    
+    pdf3.SetObservables(observable);
 
     double prob1 = pdf1.GetBinContent(0);
     double prob2 = pdf2.GetBinContent(0);    
@@ -35,7 +38,12 @@ TEST_CASE("Three pdfs no systematics"){
     }
     
     SECTION("Probability Method"){
-        REQUIRE(edMan.Probability(Event(std::vector<double>(1, -39.5))) == Approx(prob1 * prob2 * prob3));
+        Event ev(std::vector<double>(1, -39.5));
+        std::vector<std::string> observablesEvent;
+        observablesEvent.push_back("obs0");
+        observablesEvent.push_back("obs1");
+        ev.SetObservableNames(&observablesEvent);
+        REQUIRE(edMan.Probability(ev) == Approx(prob1 * prob2 * prob3));
     }
 
 }

--- a/test/unit/BinnedEDShrinkerTest.cpp
+++ b/test/unit/BinnedEDShrinkerTest.cpp
@@ -28,14 +28,17 @@ TEST_CASE("Shrinking a 1D pdf"){
     AxisCollection axes; 
     axes.AddAxis(axis1);
 
+    std::vector<std::string> observableTest;
+    observableTest.push_back("obs0");
+
     BinnedED inputDist("inputdist", axes);
     //fill with linearly increasing some data
     for(size_t i = 0; i < inputDist.GetNBins(); i++)
         inputDist.SetBinContent(i, i);
-    inputDist.SetObservables(0);
+    inputDist.SetObservables(observableTest);
 
     BinnedEDShrinker shrinker;
-    shrinker.SetBuffer(0, 3, 5); // buffer of 5 above, 3 below in dimension 0
+    shrinker.SetBuffer("test", 3, 5); // buffer of 5 above, 3 below in dimension test
 
     SECTION("With overflow bins"){
         shrinker.SetUsingOverflows(true);
@@ -79,15 +82,15 @@ TEST_CASE("2D pdf, only have buffer in one direction"){
     for (size_t i = 0; i < inputDist.GetNBins(); i++)
         inputDist.SetBinContent(i, 1);
 
-    std::vector<size_t> relevantIndicies;
-    relevantIndicies.push_back(0);
-    relevantIndicies.push_back(1);
+    std::vector<std::string> relevantIndicies;
+    relevantIndicies.push_back("test");
+    relevantIndicies.push_back("test2");
 
-    inputDist.SetObservables(ObsSet(relevantIndicies));
+    inputDist.SetObservables(relevantIndicies);
 
 
     BinnedEDShrinker shrinker;
-    shrinker.SetBuffer(1, 3, 5); // five, three from above on dim 1
+    shrinker.SetBuffer("test2", 3, 5); // five, three from above on dim test2
     
     SECTION("With Overflow bins"){
         shrinker.SetUsingOverflows(true);

--- a/test/unit/BinnedEDTest.cpp
+++ b/test/unit/BinnedEDTest.cpp
@@ -38,12 +38,11 @@ TEST_CASE("Filling a 2x2 PDF"){
 
 
     SECTION("Filling from Event with weights"){
-        std::vector<size_t> relevantIndicies;
-        relevantIndicies.push_back(0);
-        relevantIndicies.push_back(3);
-        ObsSet drep(relevantIndicies);
+        std::vector<std::string> relevantIndicies;
+        relevantIndicies.push_back("obs0");
+        relevantIndicies.push_back("obs3");
         
-        pdf.SetObservables(drep);
+        pdf.SetObservables(relevantIndicies);
 
         for(size_t i = 0; i < 100; i++){
             std::vector<double> vals;
@@ -51,8 +50,15 @@ TEST_CASE("Filling a 2x2 PDF"){
             vals.push_back(-1);
             vals.push_back(-1);
             vals.push_back(i + 1);
-
             Event evData(vals);
+
+            std::vector<std::string> observablesEvent;
+            observablesEvent.push_back("obs0");
+            observablesEvent.push_back("obs1");
+            observablesEvent.push_back("obs2");
+            observablesEvent.push_back("obs3");
+            evData.SetObservableNames(&observablesEvent);
+
             pdf.Fill(evData, 0.36);
         }
         

--- a/test/unit/BinnedNLLHTest.cpp
+++ b/test/unit/BinnedNLLHTest.cpp
@@ -23,9 +23,11 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
     double prob2 = pdf2.GetBinContent(centralBin);
     double prob3 = pdf3.GetBinContent(centralBin);
 
-    pdf1.SetObservables(0);
-    pdf2.SetObservables(0);
-    pdf3.SetObservables(0);
+    std::vector<std::string> observable;
+    observable.push_back("obs0");
+    pdf1.SetObservables(observable);
+    pdf2.SetObservables(observable);
+    pdf3.SetObservables(observable);
     
     BinnedNLLH lh;
     lh.AddPdf(pdf1);
@@ -34,6 +36,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
 
     OXSXDataSet data;
     data.AddEntry(Event(std::vector<double>(1, 0)));
+    data.SetObservableNames(observable);
     
     lh.SetDataSet(&data);
 
@@ -43,23 +46,23 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         double sumNorm    = 3;
         
         ParameterDict params;
-        params["a_norm"] = 1;
-        params["b_norm"] = 1;
-        params["c_norm"] = 1;
+        params["a"] = 1;
+        params["b"] = 1;
+        params["c"] = 1;
         lh.SetParameters(params);
         REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb));
     }
     SECTION("Correct Probability with constraint"){
-        lh.SetConstraint("a_norm", 3, 1);
+        lh.SetConstraint("a", 3, 1);
 
         double sumLogProb = -log(prob1 + prob2 + prob3);
         double sumNorm    = 3;
         double constraint = 2;
 
         ParameterDict params;
-        params["a_norm"] = 1;
-        params["b_norm"] = 1;
-        params["c_norm"] = 1;
+        params["a"] = 1;
+        params["b"] = 1;
+        params["c"] = 1;
         lh.SetParameters(params);
         REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + constraint));
     }

--- a/test/unit/CompositeEDTest.cpp
+++ b/test/unit/CompositeEDTest.cpp
@@ -12,11 +12,10 @@ TEST_CASE("Combining 1D gaussians", "[CompositeED]"){
     AnalyticED gaus1("g1", &gausF1);
     AnalyticED gaus2("g2", &gausF2);
 
-    ObsSet d1(0);
-    ObsSet d2(2);
+    ObsSet d1("obs0");
+    ObsSet d2("obs2");
     
     gaus1.SetObservables(d1);
-
     gaus2.SetObservables(d2);
 
     CompositeED compositeED = gaus1 * gaus2;
@@ -29,15 +28,22 @@ TEST_CASE("Combining 1D gaussians", "[CompositeED]"){
     vals.push_back(1);
     vals.push_back(999);
 
+    std::vector<std::string> observables;
+    observables.push_back("obs0");
+    observables.push_back("obs1");
+    observables.push_back("obs2");
+    observables.push_back("obs3");
+    observables.push_back("obs4");
 
+    Event ev(vals);
+    ev.SetObservableNames(&observables);
 
     SECTION("Check Dimensions"){
         REQUIRE(compositeED.GetNDims() == 2);
     }
 
     SECTION("Check Data Flow to internal pdfs "){
-
-        double prob  = compositeED.Probability(Event(vals));
+        double prob  = compositeED.Probability(ev);
         REQUIRE(prob == Approx(0.15141173681343614));
         
     }
@@ -45,17 +51,17 @@ TEST_CASE("Combining 1D gaussians", "[CompositeED]"){
     SECTION("Check Clone Functionality"){
         EventDistribution* clone = compositeED.Clone();
         REQUIRE(clone -> GetNDims() == 2);
-        REQUIRE(clone -> Probability(Event(vals)) == Approx(0.15141173681343614));
+        REQUIRE(clone -> Probability(ev) == Approx(0.15141173681343614));
     }
 
     SECTION("Second level of recursion"){
         Gaussian nextF = Gaussian(0.9, 0.8);
 
         AnalyticED nextED("g3", &nextF);
-        nextED.SetObservables(ObsSet(3));
+        nextED.SetObservables(ObsSet("obs3"));
         CompositeED level2 = compositeED * nextED;
         REQUIRE( level2.GetNDims() == 3 );
-        REQUIRE( level2.Probability(Event(vals)) == Approx(0.07491808959564718));
+        REQUIRE( level2.Probability(ev) == Approx(0.07491808959564718));
                                                                                          
     }
 }
@@ -83,14 +89,14 @@ TEST_CASE(" Composite of two Binned EDs"){
 
 
     // Data, where to look
-    std::vector<size_t> indicies1;
-    std::vector<size_t> indicies2;
+    std::vector<std::string> indicies1;
+    std::vector<std::string> indicies2;
 
-    indicies1.push_back(0);
-    indicies1.push_back(2);
+    indicies1.push_back("obs0");
+    indicies1.push_back("obs2");
     
-    indicies2.push_back(1);
-    indicies2.push_back(3);
+    indicies2.push_back("obs1");
+    indicies2.push_back("obs3");
 
     pdf1.SetObservables(indicies1);
     pdf2.SetObservables(indicies2);

--- a/test/unit/CutTest.cpp
+++ b/test/unit/CutTest.cpp
@@ -5,45 +5,53 @@
 #include <CutCollection.h>
 
 TEST_CASE("1D Box cut"){
-    BoxCut cut(0, 1 , 10);
+    BoxCut cut("boxCut","obs0", 1 , 10);
     cut.SetLowerLimit(1);
     cut.SetUpperLimit(10);
     
+    std::vector<std::string> observable;
+    observable.push_back("obs0");
+
     SECTION("in the middle of accepted range"){
         Event ev(std::vector<double>(1, 5));
+        ev.SetObservableNames(&observable);
         REQUIRE(cut.PassesCut(ev) == true);
     }
 
     SECTION("below accepted range"){
         Event ev(std::vector<double>(1, 0));
+        ev.SetObservableNames(&observable);
         REQUIRE(cut.PassesCut(ev) == false);
     }
 
     SECTION("above accepted range"){
         Event ev(std::vector<double>(1, 11));
+        ev.SetObservableNames(&observable);
         REQUIRE(cut.PassesCut(ev) == false);
     }
 
     SECTION("on lower boundary"){
         Event ev(std::vector<double>(1, 1));
+        ev.SetObservableNames(&observable);
         REQUIRE(cut.PassesCut(ev) == false);
     }
 
     SECTION("on upper boundary"){
         Event ev(std::vector<double>(1, 10));
+        ev.SetObservableNames(&observable);
         REQUIRE(cut.PassesCut(ev) == false);
     }
 }
 
 TEST_CASE("Several Cuts on MultiD data"){
     //  First val must be more than 2
-    LineCut lineCut(0, 2, "lower");
+    LineCut lineCut("line", "obs0", 2, "lower");
 
     // cut if second observable is between 5 and 10
-    BoxCut boxCut(1, 5, 10);
+    BoxCut boxCut("box", "obs1", 5, 10);
 
     // cut if the third value is 1 exactly
-    BoolCut boolCut(2, 1);
+    BoolCut boolCut("bool","obs2", 1);
 
     // Combine the three cuts
     CutCollection combinedCuts;
@@ -56,8 +64,12 @@ TEST_CASE("Several Cuts on MultiD data"){
     observations.push_back(1);
     observations.push_back(6);
     observations.push_back(1);
-
     Event fakeEvent(observations);
+    std::vector<std::string> observablesEvent;
+    observablesEvent.push_back("obs0");
+    observablesEvent.push_back("obs1");
+    observablesEvent.push_back("obs2");
+    fakeEvent.SetObservableNames(&observablesEvent);
 
     // Check vals
     REQUIRE(lineCut.PassesCut(fakeEvent) == false);

--- a/test/unit/DataSetGeneratorTest.cpp
+++ b/test/unit/DataSetGeneratorTest.cpp
@@ -29,12 +29,14 @@ TEST_CASE("Dataset generation by random draws"){
   sets.push_back(&testDataSet1);
   sets.push_back(&testDataSet2);
   gen.SetDataSets(sets);
+  
+  std::vector<bool> sequentialFlags(2,0);
+  gen.SetSequentialFlags(sequentialFlags);
 
   std::vector<double> rates;
   rates.push_back(2.0);
   rates.push_back(3.0);
   gen.SetExpectedRates(rates);
-
 
   SECTION("Correct number of events drawn without replacement"){
     gen.SetBootstrap(false);
@@ -48,10 +50,10 @@ TEST_CASE("Dataset generation by random draws"){
     OXSXDataSet newDataSet = gen.ExpectedRatesDataSet();
 
     //get number of events remaining in original datasets
-    std::vector<OXSXDataSet*> remainders = gen.AllRemainingEvents();   
     size_t remainingEvents = 0;
-    for (std::vector<OXSXDataSet*>::iterator i = remainders.begin(); i != remainders.end(); ++i) {  
-      OXSXDataSet* remainder = *i;
+    for (size_t i = 0; i<sets.size();i++){
+      int countsTaken = 0;
+      OXSXDataSet* remainder = gen.AllRemainingEvents(i,&countsTaken);
       remainingEvents+= remainder->GetNEntries();
     }
 
@@ -71,10 +73,10 @@ TEST_CASE("Dataset generation by random draws"){
     OXSXDataSet newDataSet = gen.ExpectedRatesDataSet();
 
     //get number of events remaining in original datasets
-    std::vector<OXSXDataSet*> remainders = gen.AllRemainingEvents();
     size_t remainingEvents = 0;
-    for (std::vector<OXSXDataSet*>::iterator i = remainders.begin(); i != remainders.end(); ++i) {
-      OXSXDataSet* remainder = *i;
+    for (size_t i = 0; i<sets.size();i++){
+      int countsTaken = 0;
+      OXSXDataSet* remainder = gen.AllRemainingEvents(i, &countsTaken);
       remainingEvents+= remainder->GetNEntries();
     }
 

--- a/test/unit/DataSetGeneratorTest.cpp
+++ b/test/unit/DataSetGeneratorTest.cpp
@@ -39,14 +39,20 @@ TEST_CASE("Dataset generation by random draws"){
   gen.SetExpectedRates(rates);
 
   SECTION("Correct number of events drawn without replacement"){
-    gen.SetBootstrap(false);
+    std::vector<bool> bootstraps;
+    bootstraps.push_back(false);
+    bootstraps.push_back(false);
+    gen.SetBootstrap(bootstraps);
     OXSXDataSet newDataSet = gen.ExpectedRatesDataSet();
     REQUIRE(newDataSet.GetNEntries() == std::accumulate(rates.begin(), rates.end(), 0));
   }
   
 
   SECTION("Correct number of events left in datasets, no replacement"){
-    gen.SetBootstrap(false);
+    std::vector<bool> bootstraps;
+    bootstraps.push_back(false);
+    bootstraps.push_back(false);
+    gen.SetBootstrap(bootstraps);
     OXSXDataSet newDataSet = gen.ExpectedRatesDataSet();
 
     //get number of events remaining in original datasets
@@ -62,14 +68,20 @@ TEST_CASE("Dataset generation by random draws"){
   
 
   SECTION("Correct number of events drawn with replacement"){
-    gen.SetBootstrap(true);
+    std::vector<bool> bootstraps;
+    bootstraps.push_back(true);
+    bootstraps.push_back(true);
+    gen.SetBootstrap(bootstraps);
     OXSXDataSet newDataSet = gen.ExpectedRatesDataSet();
     REQUIRE(newDataSet.GetNEntries() == std::accumulate(rates.begin(), rates.end(), 0));
   }
 
 
   SECTION("Correct number of events left in datasets, with replacement"){
-    gen.SetBootstrap(true);
+    std::vector<bool> bootstraps;
+    bootstraps.push_back(true);
+    bootstraps.push_back(true);
+    gen.SetBootstrap(bootstraps);
     OXSXDataSet newDataSet = gen.ExpectedRatesDataSet();
 
     //get number of events remaining in original datasets

--- a/test/unit/DistToolsTest.cpp
+++ b/test/unit/DistToolsTest.cpp
@@ -118,14 +118,14 @@ TEST_CASE("Converting 2D gaussian to binned and marginalise", "[DistTools]"){
 
     SECTION("Marginalise"){
         binnedGaus.Normalise();
-        std::vector<size_t> indicies;
-        indicies.push_back(0);
-        indicies.push_back(1);
-        indicies.push_back(2);
-
-        binnedGaus.SetObservables(indicies);
-        BinnedED xProj = binnedGaus.Marginalise(0);
-        BinnedED yProj = binnedGaus.Marginalise(1);
+        std::vector<std::string> obsNames;
+        obsNames.push_back("obs0");
+        obsNames.push_back("obs1");
+        obsNames.push_back("obs2");
+        binnedGaus.SetObservables(obsNames);
+	
+        BinnedED xProj = binnedGaus.Marginalise("ax1");
+        BinnedED yProj = binnedGaus.Marginalise("ax2");
 
         
         double xMean = xProj.Means().at(0);

--- a/test/unit/EDManagerTest.cpp
+++ b/test/unit/EDManagerTest.cpp
@@ -12,8 +12,10 @@ TEST_CASE("Add a couple of analytic pdfs"){
 
     AnalyticED pdf1("g1", &gaus1);
     AnalyticED pdf2("g2", &gaus2);
-    pdf1.SetObservables(0);
-    pdf2.SetObservables(0);
+    std::vector<std::string> observable;
+    observable.push_back("obs0");
+    pdf1.SetObservables(observable);
+    pdf2.SetObservables(observable);
     
     SECTION("initialised correctly"){
         REQUIRE(pdfMan.GetNDists() == 0);
@@ -46,6 +48,11 @@ TEST_CASE("Add a couple of analytic pdfs"){
         pdfMan.AddDist(&pdf2);
 
         Event event(std::vector<double>(1, 0));
+        std::vector<std::string> observablesEvent;
+        observablesEvent.push_back("obs0");
+        observablesEvent.push_back("obs1");
+        event.SetObservableNames(&observablesEvent);
+
         REQUIRE(pdfMan.Probability(event) == 0); // norms are zero
 
         pdfMan.SetNormalisations(std::vector<double>(2, 1));

--- a/test/unit/EventScaleTest.cpp
+++ b/test/unit/EventScaleTest.cpp
@@ -4,10 +4,18 @@
 
 TEST_CASE("Simple scale on variable number 3"){
     EventScale scaler("scaler");
-    scaler.SetObservables(ObsSet(3));
+    std::vector<std::string> observableScaler;
+    observableScaler.push_back("obs3");
+    scaler.SetOutObservables(observableScaler);
     scaler.SetScale(2);
 
     // make fake event
+    std::vector<std::string> observablesData;
+    observablesData.push_back("obs0");
+    observablesData.push_back("obs1");
+    observablesData.push_back("obs2");
+    observablesData.push_back("obs3");
+
     std::vector<double> fakeObservations;
     fakeObservations.push_back(0);
     fakeObservations.push_back(1);
@@ -15,6 +23,7 @@ TEST_CASE("Simple scale on variable number 3"){
     fakeObservations.push_back(3);
 
     Event inData(fakeObservations);
+    inData.SetObservableNames(&observablesData);
     
     // apply the shift
     Event outData = scaler(inData);

--- a/test/unit/EventShiftTest.cpp
+++ b/test/unit/EventShiftTest.cpp
@@ -4,10 +4,18 @@
 
 TEST_CASE("Simple shift on variable number 2"){
     EventShift shifter("shifter");
-    shifter.SetObservables(ObsSet(2));
+    std::vector<std::string> observableShifter;
+    observableShifter.push_back("obs2");
+    shifter.SetOutObservables(observableShifter);
     shifter.SetShift(1);
 
     // make fake event
+    std::vector<std::string> observablesData;
+    observablesData.push_back("obs0");
+    observablesData.push_back("obs1");
+    observablesData.push_back("obs2");
+    observablesData.push_back("obs3");
+
     std::vector<double> fakeObservations;
     fakeObservations.push_back(0);
     fakeObservations.push_back(1);
@@ -15,7 +23,8 @@ TEST_CASE("Simple shift on variable number 2"){
     fakeObservations.push_back(3);
 
     Event inData(fakeObservations);
-    
+    inData.SetObservableNames(&observablesData);
+
     // apply the shift
     Event outData = shifter(inData);
     std::vector<double> modifiedObs = outData.GetData();

--- a/test/unit/EventSystematicManagerTest.cpp
+++ b/test/unit/EventSystematicManagerTest.cpp
@@ -16,29 +16,49 @@ TEST_CASE("3 observable event, shift and scale"){
     // Create a fake event
     std::vector<double> data(3, 1);
     Event event(data);
+    
+    std::vector<std::string> obsData; 
+    obsData.push_back("obs0");
+    obsData.push_back("obs1");
+    obsData.push_back("obs2");
+    event.SetObservableNames(&obsData);
 
     SECTION("Acting of different observables"){
-        scaler.SetObservables(ObsSet(0));
-        shifter.SetObservables(ObsSet(1));
+        
+        std::vector<std::string> obsScaler; 
+        obsScaler.push_back("obs0");
 
+        std::vector<std::string> obsShifter;
+        obsShifter.push_back("obs1");
+
+        scaler.SetInObservables(obsScaler);
+        scaler.SetOutObservables(obsScaler);
+
+        shifter.SetInObservables(obsShifter);
+        shifter.SetOutObservables(obsShifter);
+	
         EventSystematicManager sysMan;
         sysMan.Add(&scaler);
         sysMan.Add(&shifter);
 
-        // transform
-        Event modified = sysMan.ApplySystematics(event);
 
-        // Test
+        // transform and test
+        Event modified = sysMan.ApplySystematics(event);      
         REQUIRE(modified.GetData().size() == 3);
-        REQUIRE(modified.GetData().at(0) == 3);
-        REQUIRE(modified.GetData().at(1) == 2);
+        REQUIRE(modified.GetData().at(0) == (1*3));
+        REQUIRE(modified.GetData().at(1) == (1+1));
         REQUIRE(modified.GetData().at(2) == 1);
     }
 
     SECTION("Acting on same observables"){
+        std::vector<std::string> obsScalerAndShifter; 
+        obsScalerAndShifter.push_back("obs0");
+
         // Act in the order added to sysMan
-        scaler.SetObservables(ObsSet(0));
-        shifter.SetObservables(ObsSet(0));
+        scaler.SetInObservables(obsScalerAndShifter);
+        shifter.SetInObservables(obsScalerAndShifter);
+        scaler.SetOutObservables(obsScalerAndShifter);
+        shifter.SetOutObservables(obsScalerAndShifter);
 
         EventSystematicManager sysMan;
         sysMan.Add(&scaler);
@@ -53,11 +73,16 @@ TEST_CASE("3 observable event, shift and scale"){
         REQUIRE(modified.GetData().at(2) == 1);
     }
 
-
     SECTION("Acting on same observables - otherway around"){
         // Act in the order added to sysMan
-        scaler.SetObservables(ObsSet(0));
-        shifter.SetObservables(ObsSet(0));
+        std::vector<std::string> obsScalerAndShifter; 
+        obsScalerAndShifter.push_back("obs0");
+
+        // Act in the order added to sysMan
+        scaler.SetInObservables(obsScalerAndShifter);
+        shifter.SetInObservables(obsScalerAndShifter);
+        scaler.SetOutObservables(obsScalerAndShifter);
+        shifter.SetOutObservables(obsScalerAndShifter);
 
         EventSystematicManager sysMan;
         sysMan.Add(&shifter);

--- a/test/unit/HistToolsTest.cpp
+++ b/test/unit/HistToolsTest.cpp
@@ -18,20 +18,20 @@ TEST_CASE("Producing  histograms from a set of axes"){
         typedef std::set<std::pair<std::string, std::string> > CombSet;
         CombSet l2combinations =  Combinations::AllCombsNoDiag(dimensionList);
         
-        std::vector<Histogram> hists = HistTools::MakeAllHists(axes, l2combinations);
+        std::map<std::string, Histogram> hists = HistTools::MakeAllHists(axes, l2combinations);
         int i = 0;
         for(CombSet::iterator it = l2combinations.begin(); it != l2combinations.end(); ++it){
-            REQUIRE(hists.at(i).GetAxes().GetAxis(0).GetName() == it->first);
-            REQUIRE(hists.at(i).GetAxes().GetAxis(1).GetName() == it->second);
+            REQUIRE(hists[it->first + "_" + it->second].GetAxes().GetAxis(0).GetName() == it->first);
+            REQUIRE(hists[it->first + "_" + it->second].GetAxes().GetAxis(1).GetName() == it->second);
             i++;
         }
     
     }
     
     SECTION("1D"){
-        std::vector<Histogram> hists = HistTools::MakeAllHists(axes, dimensionList);
+        std::map<std::string, Histogram> hists = HistTools::MakeAllHists(axes, dimensionList);
         for(size_t i = 0; i < hists.size(); i++){
-            REQUIRE(hists.at(i).GetAxes().GetAxis(0).GetName() == dimensionList.at(i));
+            REQUIRE(hists[dimensionList.at(i)].GetAxes().GetAxis(0).GetName() == dimensionList.at(i));
         }
     }
         

--- a/test/unit/ObservableSetTest.cpp
+++ b/test/unit/ObservableSetTest.cpp
@@ -3,54 +3,54 @@
 #include <OXSXDataSet.h>
 
 TEST_CASE("Build from one index"){
-     ObsSet drep(19);
+    ObsSet drep("obs19");
     REQUIRE(drep.GetNObservables() == 1);
-    REQUIRE(drep.GetIndex(0) == 19);
+    REQUIRE(drep.GetIndex("obs19") == 0);
 }
 
 TEST_CASE("Build from vec"){
-    std::vector<size_t> indices;
-    indices.push_back(5);
-    indices.push_back(9);
-    indices.push_back(11);
+    std::vector<std::string> obsNames;
+    obsNames.push_back("obs5");
+    obsNames.push_back("obs9");
+    obsNames.push_back("obs11");
 
-     ObsSet drep(indices);
+    ObsSet drep(obsNames);
     REQUIRE(drep.GetNObservables() == 3);
-    REQUIRE(drep.GetIndex(0) == 5);
-    REQUIRE(drep.GetIndex(1) == 9);
-    REQUIRE(drep.GetIndex(2) == 11);
+    REQUIRE(drep.GetIndex("obs5") == 0);
+    REQUIRE(drep.GetIndex("obs9") == 1);
+    REQUIRE(drep.GetIndex("obs11") == 2);
 
     SECTION("Then copy construct"){
-         ObsSet drep2(drep);
+        ObsSet drep2(drep);
         REQUIRE(drep2.GetNObservables() == 3);
-        REQUIRE(drep2.GetIndex(0) == 5);
-        REQUIRE(drep2.GetIndex(1) == 9);
-        REQUIRE(drep2.GetIndex(2) == 11);
+        REQUIRE(drep2.GetIndex("obs5") == 0);
+        REQUIRE(drep2.GetIndex("obs9") == 1);
+        REQUIRE(drep2.GetIndex("obs11") == 2);
         
     }
 
     SECTION("Testing Inverse Functionality"){
-        REQUIRE(drep.GetDataIndexPos(11) == 2);
-        REQUIRE(drep.GetDataIndexPos(5) == 0);
-        REQUIRE(drep.GetDataIndexPos(9) == 1);
+        REQUIRE(drep.GetNames().at(2) == "obs11");
+        REQUIRE(drep.GetNames().at(0) == "obs5");
+        REQUIRE(drep.GetNames().at(1) == "obs9");
     }
 
 
 }
 
 
-TEST_CASE("Looking for the relative indices of 2d rep in 4d rep"){
-    std::vector<size_t> smallRepIndices;
-    smallRepIndices.push_back(6);
-    smallRepIndices.push_back(0);
+TEST_CASE("Looking for the relative obsNames of 2d rep in 4d rep"){
+    std::vector<std::string> smallRepObsNames;
+    smallRepObsNames.push_back("obs6");
+    smallRepObsNames.push_back("obs0");
 
-    std::vector<size_t> bigRepIndices;
-    bigRepIndices.push_back(0);
-    bigRepIndices.push_back(3);
-    bigRepIndices.push_back(6);
+    std::vector<std::string> bigRepObsNames;
+    bigRepObsNames.push_back("obs0");
+    bigRepObsNames.push_back("obs3");
+    bigRepObsNames.push_back("obs6");
 
-     ObsSet bigRep(bigRepIndices);
-     ObsSet smallRep(smallRepIndices);
+     ObsSet bigRep(bigRepObsNames);
+     ObsSet smallRep(smallRepObsNames);
 
     std::vector<size_t> relativeIndices = smallRep.GetRelativeIndices(bigRep);
 
@@ -58,35 +58,6 @@ TEST_CASE("Looking for the relative indices of 2d rep in 4d rep"){
     REQUIRE(relativeIndices.at(0) == 2);
     REQUIRE(relativeIndices.at(1) == 0);
     
-}
-
-TEST_CASE("Creating a  ObsSet from a DataSet by observable name"){
-    // create a dummy dataset with some observables in it
-    std::vector<std::string> observables;
-    observables.push_back("obs_1");
-    observables.push_back("obs_2");
-    observables.push_back("obs_3");
-    observables.push_back("obs_4");
-
-    OXSXDataSet dataSet;
-    dataSet.SetObservableNames(observables);
-    
-    // now ask the data set for the representation corresponding to obs_4, obs_3, obs_2
-    std::vector<std::string> requestedObs;
-    requestedObs.push_back("obs_4");
-    requestedObs.push_back("obs_3");
-    requestedObs.push_back("obs_2");
-
-     ObsSet generatedRep = dataSet.MakeDataRep(requestedObs);
-
-    //check it did it right
-    REQUIRE(generatedRep.GetNObservables() == requestedObs.size());
-    for(size_t i = 0; i < requestedObs.size(); i++){
-        size_t generatedIndex = generatedRep.GetIndices().at(i);
-        std::string generatedName = observables.at(generatedIndex);
-        REQUIRE(generatedName == requestedObs.at(i));
-        
-    }
 }
 
                 


### PR DESCRIPTION
Some of the core structure has been changed on the HMC branch, but the unit tests have not been updated. This PR deals with that. A lot of the changes come from that fact that the `ObsSet` is now created by observable names (strings) rather than indices (size_t), but other changes too.

Second small commit regards a bug in DataSetGenerator in the case when the number of requested events = number of events available, which should still be a valid request. (`max` is one less than `origData -> GetNEntries()`)

Note: There will be still be at least one unit test failing, until the bug fix for EventShift in PR #9 is not merged. After that they should all be fine.