### PR TITLE
Make bootstrap in DataSetgenerator a vector

### DIFF
--- a/src/data/DataSetGenerator.cpp
+++ b/src/data/DataSetGenerator.cpp
@@ -51,7 +51,7 @@ DataSetGenerator::ExpectedRatesDataSet(std::vector<int>* eventsTaken_){
     dataSet.SetObservableNames(fDataSets.at(0)->GetObservableNames());
     for(size_t i = 0; i < fDataSets.size(); i++){
         unsigned expectedCounts = round(fExpectedRates.at(i));
-	if(fBootstrap)
+	if(fBootstraps.at(i))
 	  RandomDrawsWithReplacement(i, expectedCounts, dataSet);
 	else{
 	  if(fSequentialFlags.at(i))
@@ -88,7 +88,7 @@ DataSetGenerator::PoissonFluctuatedDataSet(std::vector<int>* eventsTaken_){
     for(size_t i = 0; i < fDataSets.size(); i++){
         int counts = Rand::Poisson(fExpectedRates.at(i));
 
-        if(fBootstrap)
+        if(fBootstraps.at(i))
             RandomDrawsWithReplacement(i, counts, dataSet);
 
         else{
@@ -259,14 +259,14 @@ DataSetGenerator::AddDataSet(DataSet* data_, double rate_, bool flag_){
 }
 
 
-bool
+const std::vector<bool>&
 DataSetGenerator::GetBootstrap() const{
-    return fBootstrap;
+    return fBootstraps;
 }
 
 void
-DataSetGenerator::SetBootstrap(bool b_){
-    fBootstrap = b_;
+DataSetGenerator::SetBootstrap(const std::vector<bool>& b_){
+    fBootstraps = b_;
 }
 
 void 

--- a/src/data/DataSetGenerator.h
+++ b/src/data/DataSetGenerator.h
@@ -16,7 +16,7 @@ class Event;
 
 class DataSetGenerator{
  public:
-    DataSetGenerator() : fBootstrap(false){}
+    DataSetGenerator() {}
     void SetDataSets(const std::vector<DataSet*> sets_);
     void SetExpectedRates(const std::vector<double>& rates_);
 
@@ -25,8 +25,8 @@ class DataSetGenerator{
     void SetCuts(const CutCollection& cuts_);
     void AddCut(const Cut& cut_);
 
-    bool GetBootstrap() const;
-    void SetBootstrap(bool);
+    const std::vector<bool>& GetBootstrap() const;
+    void SetBootstrap(const std::vector<bool>&);
 
     OXSXDataSet ExpectedRatesDataSet(std::vector<int>* eventsTaken_ = NULL);
     OXSXDataSet PoissonFluctuatedDataSet(std::vector<int>* eventsTaken_ = NULL);
@@ -49,7 +49,7 @@ class DataSetGenerator{
     void                     RandomDrawsNoReplacement(size_t handleIndex_, int nEvents_, OXSXDataSet& data_);
     void                     SequentialDrawsNoReplacement(size_t handleIndex_, int nEvents_, OXSXDataSet& data_);
     void                     RandomDrawsWithReplacement(size_t handleIndex_, int nEvents_, OXSXDataSet& data_);
-    bool                     fBootstrap;
+    std::vector<bool>        fBootstraps;
     CutCollection            fCuts;
 };
 


### PR DESCRIPTION
Allows for setting the flag for replacing events in the detatset to be set separately for each contribution rather than globally.