### PR TITLE
Make util code Python 2 & 3 compatible

### DIFF
--- a/util/calc_eff_rad
+++ b/util/calc_eff_rad
@@ -6,6 +6,7 @@
 
 R0 = 6005
 
+from __future__ import print_function
 import argparse
 import os
 import sys
@@ -13,7 +14,7 @@ from array import array
 try:
     from ROOT import TFile, TTree, TNtuple
 except ImportError:
-    print "Cant find root lib is it in $PYTHONPATH?"
+    print("Cant find root lib is it in $PYTHONPATH?")
     sys.exit()
 
 def eff_r(x, y, z):
@@ -26,29 +27,29 @@ def to_eff_r(file_name, tree_name, coord_names, outfile, r_name, coords_to_keep)
     in_file = TFile(file_name)
     tree    = in_file.Get(tree_name)
     if not tree:
-        print "Error: No tree named %s in %s" %(tree_name, file_name)
+        print("Error: No tree named %s in %s" %(tree_name, file_name))
         sys.exit()
         
     # Check branches
     branches = [x.GetName() for x in tree.GetListOfBranches()]
     for b in coord_names:
         if not b in branches:
-            print "Error branch '%s' not a branch in input tree" %(b)
-            print "Branches available are: \n"
-            print "\t".join(branches)
+            print("Error branch '%s' not a branch in input tree" %(b))
+            print("Branches available are: \n")
+            print("\t".join(branches))
             sys.exit()
     
     other_branches = list(set(branches) - set(coord_names)) + coords_to_keep
 
     out_file = TFile(outfile, "RECREATE")
     new_branches = list(other_branches) + [r_name]
-    print new_branches
+    print(new_branches)
     nt       = TNtuple("output", "", ":".join(new_branches))
 
     n_events = tree.GetEntries()
     for i, entry in enumerate(tree):
         if not i % 1000000:
-            print "%i/%i"%(i, n_events)
+            print("%i/%i"%(i, n_events))
         x = entry.__getattr__(coord_names[0])
         y = entry.__getattr__(coord_names[1])
         z = entry.__getattr__(coord_names[2])
@@ -60,9 +61,9 @@ def to_eff_r(file_name, tree_name, coord_names, outfile, r_name, coords_to_keep)
     nt.Write()
     out_file.Close()
 
-    print "Written %i entries of branch(es) '%s' \nto tree %s  \nin file %s" %(n_events,
+    print("Written %i entries of branch(es) '%s' \nto tree %s  \nin file %s" %(n_events,
                                                                                ":".join(new_branches),
-                                                                               "output", outfile)
+                                                                               "output", outfile))
 
 
 if __name__ == "__main__":

--- a/util/make_simple_data
+++ b/util/make_simple_data
@@ -1,3 +1,4 @@
+#! /usr/bin/env python
 '''
 Quick script to generate fake data for example/simpleFit.cpp
 

--- a/util/prune_flat_tree
+++ b/util/prune_flat_tree
@@ -3,6 +3,7 @@
 ################################################################
 # Prune away branches of a flat root tree to produce an ntuple #
 ################################################################
+from __future__ import print_function
 import argparse
 import os
 import sys
@@ -10,29 +11,29 @@ from array import array
 try:
     from ROOT import TFile, TTree, TNtuple, TChain
 except ImportError:
-    print "Cant find root lib is it in $PYTHONPATH?"
+    print("Cant find root lib is it in $PYTHONPATH?")
     sys.exit()
 
 def make_ntup(file_name, tree_name,  branches, outfile, n_events, new_tree_name):
     if new_tree_name == "":
         new_tree_name = tree_name
 
-    print file_name
+    print(file_name)
     
     # Get the event tree 
     tree = TChain(tree_name)
     tree.Add(file_name)
     if not tree:
-        print "Error: No tree named %s in %s" %(tree_name, file_name)
+        print("Error: No tree named %s in %s" %(tree_name, file_name))
         sys.exit()
     
     # Check branches exist
     branches_avail = [x.GetName() for x in tree.GetListOfBranches()]
     for b in branches:
         if not b in branches_avail:
-            print "Error branch '%s' not a branch in input tree" %(b)
-            print "Branches available are: \n"
-            print "\t".join(branches_avail)
+            print("Error branch '%s' not a branch in input tree" %(b))
+            print("Branches available are: \n")
+            print("\t".join(branches_avail))
             sys.exit()
 
     # output
@@ -50,15 +51,15 @@ def make_ntup(file_name, tree_name,  branches, outfile, n_events, new_tree_name)
         nt.Fill(vals)
         
         if (index % 100000 == 0):
-            print index, "/", n_events
+            print(index, "/", n_events)
     # Save
     out_file.cd()
     nt.Write()
     out_file.Close()
 
-    print "Written %i entries of branch(es) '%s' \nto tree %s  \nin file %s" %(n_events, 
+    print("Written %i entries of branch(es) '%s' \nto tree %s  \nin file %s" %(n_events, 
                                                                              ":".join(branches), 
-                                                                             new_tree_name, outfile)
+                                                                             new_tree_name, outfile))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Python code in the util sub-directory has been only compatible with Python 2 historically. This PR makes the minor modifications necessary so that this code should be able to run with both Python 2 & 3. This is important as future users will certainly want to use Python 3; Python 2 is going/has gone end-of-life. Moreover, the solar oscillation analysis code is now using Python 3, and breaks when trying to call `util/prune_flat_tree`.

I have used the Python `2to3` package to get the code usable in Python 3; to keep backwards compatibility for Python 2 I have added the `from __future__ import ... ` lines where appropriate. The only changes `2to3` has made are the syntax for `print()` statements.

I have tested `util/prune_flat_tree` with both the standard Oxford RAT environment of ROOT 5.34.36 and Python 2.7, as well as my solar analysis environment of ROOT 6.22.2 and Python 3.8. The code runs successfully in both cases (no crashing when a `print()` statement is interpreted). I have also tested `util/make_simple_data`, also successful.

I have made two very small additional changes apart from this:

- A shebang has been added to `util/make_simple_data` like the other `util` python code.
- The empty file `util/read_root_ds` is deleted.