### PR TITLE
Set C++11 standard & Add compiler warning flags

### DIFF
--- a/config/SConscript
+++ b/config/SConscript
@@ -4,7 +4,7 @@ import buildhelp
 import platform
 import os
 
-env = Environment(CXXFLAGS = "-O2 -std=c++11 -pedantic -Wall -Wextra -fdiagnostics-color")
+env = Environment(CXXFLAGS = "-O2 -std=c++11 -pedantic -Wall -Wextra")
 if env.GetOption('clean'):
     Return('env')
 

--- a/config/SConscript
+++ b/config/SConscript
@@ -4,7 +4,7 @@ import buildhelp
 import platform
 import os
 
-env = Environment(CXXFLAGS = "-O2")
+env = Environment(CXXFLAGS = "-O2 -std=c++11 -pedantic -Wall -Wextra -fdiagnostics-color")
 if env.GetOption('clean'):
     Return('env')
 


### PR DESCRIPTION
Unless a more up-to-date compiler is used, by default the g++ compiler installed on CentOS7 uses the C++98 standard. This PR adds the `-std=c++11` compiler flag to enforce the C++11 standard. In so doing, our code can now use the multitude of ["new" features added in this standard!](https://en.cppreference.com/w/cpp/11) (I'm most excited for the ability to use range-based for-loops.)

In addition to this, I added the `-pedantic -Wall -Wextra -fdiagnostics-color` flags so that any warnings now get displayed when compiling, and they get nicely coloured.

I have tested the compilation under "standard" conditions used by Oxford SNO+ members: CentOS7 with the default g++ version 4.8.5, and default CentOS7 "snocave" dependencies. This master branch still compiles successfully, as do the associated unit tests. However, we now observe a boatload of warning messages appearing: I am planning on fixing these warnings in the near future.

Because I believe the ability to use C++11 brings an immediate benefit to our code, I will also shortly be opening a PR to the `hmc` branch with this commit also.