### PR TITLE
Set C++11 standard & Add compiler warning flags -- For HMC

### DIFF
--- a/config/SConscript
+++ b/config/SConscript
@@ -4,7 +4,7 @@ import buildhelp
 import platform
 import os
 
-env = Environment(CXXFLAGS = "-O2 -std=c++11 -pedantic -Wall -Wextra -fdiagnostics-color")
+env = Environment(CXXFLAGS = "-O2 -std=c++11 -pedantic -Wall -Wextra")
 if env.GetOption('clean'):
     Return('env')
 

--- a/config/SConscript
+++ b/config/SConscript
@@ -4,7 +4,7 @@ import buildhelp
 import platform
 import os
 
-env = Environment(CXXFLAGS = "-O2")
+env = Environment(CXXFLAGS = "-O2 -std=c++11 -pedantic -Wall -Wextra -fdiagnostics-color")
 if env.GetOption('clean'):
     Return('env')
 


### PR DESCRIPTION
This is identical to PR #14, except the change is made to the `hmc` branch.

This allows the benefits that these new compiler flags bring to be used by those working on the `hmc` branch, before the eventual merging of this branch into `master`.

As with PR #14, I confirmed that the addition of these flags have no effect on whether the code as-is compiles; compilation now just spews the numerous warnings present in the code base.