### PR TITLE
Save full MCMC Chain as a TTree

### DIFF
--- a/src/optimise/MCMC.cpp
+++ b/src/optimise/MCMC.cpp
@@ -138,6 +138,7 @@ MCMC::SetInitialTrial(const ParameterDict& trial_){
     fInitialTrial = trial_;
 }
 
+
 ParameterDict
 MCMC::GetInitialTrial() const{
     return fInitialTrial;
@@ -179,10 +180,9 @@ MCMC::Optimise(TestStatistic* testStat_){
         }
     }
 
-
     std::cout << "MCMC::Initial Position @:" << std::endl;
     for(ParameterDict::iterator it = fCurrentStep.begin(); it != fCurrentStep.end(); ++it)
-          std::cout << it->first << " : " << it->second << std::endl;
+        std::cout << it->first << " : " << it->second << std::endl;
     std::cout << std::endl;
 
     pTestStatistic->SetParameters(fCurrentStep);
@@ -195,7 +195,6 @@ MCMC::Optimise(TestStatistic* testStat_){
     
     // 2. Loop step through the space a fixed number of times
     for(unsigned i = 0; i < fMaxIter; i++){
-
         if(!(i%100000) && i)
             std::cout << i << "  /  " << fMaxIter
                       << "\t" << fSamples.GetAcceptanceRate()
@@ -203,6 +202,8 @@ MCMC::Optimise(TestStatistic* testStat_){
                       << "\t" << fSamples.GetAutoCorrelations()[10]
                       << "\t" << fSamples.GetAutoCorrelations()[100]
                       << std::endl;
+
+
         // b. Propose a new step according
         ParameterDict proposedStep = fSampler.Draw(fCurrentStep);
 
@@ -211,7 +212,6 @@ MCMC::Optimise(TestStatistic* testStat_){
 
         // d. log
         fSamples.Fill(fCurrentStep, fCurrentVal, accepted);
-
     }
     std::cout << "MCMC:: acceptance rate = " << fSamples.GetAcceptanceRate()
               << std::endl;

--- a/src/optimise/MCMC.cpp
+++ b/src/optimise/MCMC.cpp
@@ -7,8 +7,6 @@
 #include <ContainerTools.hpp>
 #include <Rand.h>
 #include <iostream>
-#include <string>
-#include <algorithm>
 #include <math.h> //isinf
 
 void

--- a/src/optimise/MCMC.h
+++ b/src/optimise/MCMC.h
@@ -5,6 +5,8 @@
 #include <MCMCSamples.h>
 #include <MCSampler.h>
 #include <set>
+#include "TStopwatch.h"
+#include <TTree.h>
 
 class TestStatistic;
 class MCMC : public Optimiser{
@@ -45,11 +47,16 @@ class MCMC : public Optimiser{
     bool GetSaveFullHistogram() const;
     void SetSaveFullHistogram(bool);
 
+    bool GetSaveChain() const;
+    void SetSaveChain(bool);
+
     void SetHistogramAxes(const AxisCollection&);
     AxisCollection GetHistogramAxes() const;
 
     void SetInitialTrial(const ParameterDict&);
     ParameterDict GetInitialTrial() const;
+
+    TTree* GetChain() const;
 
     const MCMCSamples& GetSamples() const;
 
@@ -78,5 +85,12 @@ class MCMC : public Optimiser{
     MCSampler& fSampler;
     
     bool   StepAccepted(const ParameterDict& proposedStep_);
+
+    TTree *fChain;
+    bool fAccepted;
+    int fStepNumber;
+    double fStepTime;
+    TStopwatch stepClock;
+    bool fSaveChain;
 };
 #endif

--- a/src/optimise/MCMC.h
+++ b/src/optimise/MCMC.h
@@ -5,8 +5,6 @@
 #include <MCMCSamples.h>
 #include <MCSampler.h>
 #include <set>
-#include "TStopwatch.h"
-#include <TTree.h>
 
 class TestStatistic;
 class MCMC : public Optimiser{

--- a/src/optimise/MCMC.h
+++ b/src/optimise/MCMC.h
@@ -83,8 +83,6 @@ class MCMC : public Optimiser{
     MCSampler& fSampler;
     
     bool   StepAccepted(const ParameterDict& proposedStep_);
-
     bool fSaveChain;
-
 };
 #endif

--- a/src/optimise/MCMC.h
+++ b/src/optimise/MCMC.h
@@ -56,8 +56,6 @@ class MCMC : public Optimiser{
     void SetInitialTrial(const ParameterDict&);
     ParameterDict GetInitialTrial() const;
 
-    TTree* GetChain() const;
-
     const MCMCSamples& GetSamples() const;
 
  private:
@@ -86,12 +84,7 @@ class MCMC : public Optimiser{
     
     bool   StepAccepted(const ParameterDict& proposedStep_);
 
-    TTree *fChain;
-    bool fAccepted;
-    int fStepNumber;
-    double fStepTime;
-    TStopwatch stepClock;
     bool fSaveChain;
-    std::vector<double> parvals;
+
 };
 #endif

--- a/src/optimise/MCMC.h
+++ b/src/optimise/MCMC.h
@@ -92,5 +92,6 @@ class MCMC : public Optimiser{
     double fStepTime;
     TStopwatch stepClock;
     bool fSaveChain;
+    std::vector<double> parvals;
 };
 #endif

--- a/src/optimise/MCMCSamples.cpp
+++ b/src/optimise/MCMCSamples.cpp
@@ -14,6 +14,16 @@ MCMCSamples::GetSaveFullHistogram() const{
     return fSaveFullHistogram;
 }
 
+bool
+MCMCSamples::GetSaveChain() const{
+  return fSaveChain;
+}
+
+void
+MCMCSamples::SetSaveChain(bool b_){
+  fSaveChain = b_;
+}
+
 void
 MCMCSamples::FillProjections(const ParameterDict& params_){
     // 1D
@@ -86,6 +96,32 @@ MCMCSamples::InitialiseHistograms(){
         f1DProjections = HistTools::MakeAllHists(histAxes, paramNames);
     }
 
+    if(fSaveChain){
+      stepClock.Start();
+      int parameterNumber = 0;
+      fChain = new TTree("posteriors", "Posterior_Distributions");
+      fChain->Branch("LogL", &fCurrentVal, "LogL/D");
+      fChain->Branch("Accepted", &fAccepted, "Accepted/O");
+      fChain->Branch("Step", &fStepNumber, "Step/I");
+      fChain->Branch("StepTime", &fStepTime, "StepTime/D");
+
+      parvals.reserve(paramNames.size());
+      for(std::set<std::string>::iterator it =  paramNames.begin();
+	  it != paramNames.end(); ++it){
+	//Strip out "-" from parameter names
+	const std::string& tempname = *it;
+	std::string bname = tempname; 
+	if(bname.find("-") != std::string::npos)
+          bname.replace(bname.find("-"), 1, "_");
+        char bit[40] = "";
+        strcat(bit, bname.c_str());
+        strcat(bit, "/D");
+        fChain->Branch( bname.c_str(), &parvals[parameterNumber], bit);
+        parameterNumber++;
+      }
+    }
+
+
     fInitialised = true;
 }
 
@@ -107,7 +143,22 @@ MCMCSamples::Fill(const ParameterDict& params_, double val_, bool accepted_){
     if(accepted_)
         fAcceptedSteps++;
     
+    if(fSaveChain){
+      int parameterNumber = 0;
+      for( ParameterDict::const_iterator it = params_.begin(); it != params_.end(); ++it){
+	parvals[parameterNumber] = it->second;
+	parameterNumber++;
+      }
+      fCurrentVal = val_;
+      fStepNumber = fTotalSteps;
+      fAccepted = accepted_;
+      fStepTime = stepClock.RealTime();
+      stepClock.Start();
+      fChain->Fill();      
+    }
+
     fTotalSteps++;
+
 }
 
 
@@ -125,6 +176,11 @@ MCMCSamples::Get2DProjections() const{
 const Histogram&
 MCMCSamples::GetHistogram() const{
     return fHist;   
+}
+
+TTree*
+MCMCSamples::GetChain() const{
+  return fChain;
 }
 
 const std::vector< std::vector<double> >&

--- a/src/optimise/MCMCSamples.cpp
+++ b/src/optimise/MCMCSamples.cpp
@@ -121,7 +121,6 @@ MCMCSamples::InitialiseHistograms(){
       }
     }
 
-
     fInitialised = true;
 }
 
@@ -158,7 +157,6 @@ MCMCSamples::Fill(const ParameterDict& params_, double val_, bool accepted_){
     }
 
     fTotalSteps++;
-
 }
 
 

--- a/src/optimise/MCMCSamples.h
+++ b/src/optimise/MCMCSamples.h
@@ -78,7 +78,6 @@ class MCMCSamples{
     TStopwatch stepClock;
     bool fSaveChain;
     std::vector<double> parvals;
-
 };
 
 #endif

--- a/src/optimise/MCMCSamples.h
+++ b/src/optimise/MCMCSamples.h
@@ -4,6 +4,8 @@
 #include <Histogram.h>
 #include <ParameterDict.h>
 #include <AutoCorrelationCalc.h>
+#include "TStopwatch.h"
+#include <TTree.h>
 
 class MCMC;
 class MCMCSamples{
@@ -26,8 +28,13 @@ class MCMCSamples{
     bool GetSaveFullHistogram() const;
     void SetSaveFullHistogram(bool);
 
+    bool GetSaveChain() const;
+    void SetSaveChain(bool);
+
     double   GetRejectionRate() const;
     double   GetAcceptanceRate() const;
+
+    TTree* GetChain() const;
 
     void Fill(const ParameterDict&, double val_, bool accepted_);
 
@@ -62,6 +69,15 @@ class MCMCSamples{
 
     Histogram fHist;
     std::vector< std::vector<double> > fSample;
+
+    TTree *fChain;
+    bool fAccepted;
+    double fCurrentVal;
+    int fStepNumber;
+    double fStepTime;
+    TStopwatch stepClock;
+    bool fSaveChain;
+    std::vector<double> parvals;
 
 };
 


### PR DESCRIPTION
This PR adds the ability to save information about each step in the Markov chain. The main difference over what's already saved in MCMCSamples is that this allows you to see how parameter values and the LLH evolve as a function of step number. It also allows a bit more flexibility with things like the burn in being able to be set/changed after the fit is run, and if you wanted to you can make any number of plots eg something like Plot Parameter A vs Parameter B for all steps when Parameter C < 10.0 (just an example, not sure we'd be making plots like that all the time but could be useful for trying de-tangle background correlations etc)

There's four files changed:

**MCMC.cpp and MCMC.h**
Just adding two functions to Get and Set the flag on whether to save the tree or not. Also adding the flag itself as a bool

**MCMCSamples.cpp and MCMCSamples.h**
The meat of it's in MCMCSamples. Again we have the Get and Set flag functions. The MCMC SetSaveChain function can be set by the analysers fitter. This then calls the MCMCSamples SetSaveChain.
There's an if statement on the flag in InitialiseHistograms, where the branch addresses are set to the relevant values.
Then in the loop over all steps, set each branch value and fill the tree

I'm putting in a pull request on the bb-likelihood-analysis code for an example of using it in a fitter
Overall, it's only adding to the MCMC and MCMCSamples code so shouldn't break anything else, and it's all hidden in if loops so can be switched off easy. But any suggestions on functionality and coding standards are welcomed!