### PR TITLE
Add asymmetric constraint

### DIFF
--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -189,6 +189,11 @@ BinnedNLLH::SetConstraint(const std::string& paramName_, double mean_, double si
     fConstraints[paramName_] = QuadraticConstraint(mean_, sigma_);
 }
 
+void
+BinnedNLLH::SetConstraint(const std::string& paramName_, double mean_, double sigma_lo_, double sigma_hi_) {
+    fConstraints[paramName_] = QuadraticConstraint(mean_, sigma_lo_, sigma_hi_);
+}
+
 
 double
 BinnedNLLH::GetSignalCutEfficiency() const{

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -28,6 +28,7 @@ class BinnedNLLH : public TestStatistic{
     void   AddSystematics(const std::vector<Systematic*>, const std::vector<std::string>&);
 
     void   SetConstraint(const std::string& paramName_, double mean_, double sigma_);
+    void   SetConstraint(const std::string& paramName_, double mean_, double sigma_lo_, double sigma_hi_);
     
     void SetNormalisations(const std::vector<double>& norms_);
     std::vector<double> GetNormalisations() const;

--- a/src/teststat/QuadraticConstraint.h
+++ b/src/teststat/QuadraticConstraint.h
@@ -7,16 +7,25 @@
 
 class QuadraticConstraint{
  public:
- QuadraticConstraint(){}
- QuadraticConstraint(double mean_, double width_) : 
-    fMean(mean_), fWidth(width_) {}
+    QuadraticConstraint(){}
+    // Symmetric constraint constructor
+    QuadraticConstraint(double mean_, double width_) : 
+        fMean(mean_), fWidth(width_), fWidth_lo(0), is_asym(false) {}
+    // Asymmetric constraint constructor
+    QuadraticConstraint(double mean_, double width_hi, double width_lo) :
+        fMean(mean_), fWidth(width_hi), fWidth_lo(width_lo), is_asym(true) {}
 
     double Evaluate(double val_) const {
-        return (val_ - fMean) * (val_ - fMean) / (2 * fWidth * fWidth);
+        double sigma;
+        if (is_asym) { sigma = (val_ >= fMean) ? fWidth : fWidth_lo; }
+        else { sigma = fWidth; }
+        return (val_ - fMean) * (val_ - fMean) / (2 * sigma * sigma);
     }
     
  private:
     double fMean;
     double fWidth;
+    double fWidth_lo;
+    bool is_asym;
 };
 #endif

--- a/src/teststat/QuadraticConstraint.h
+++ b/src/teststat/QuadraticConstraint.h
@@ -1,6 +1,7 @@
 /***********************************************************************************************/
 /* A quadratic constraint on a fit parameter, for log likelihood and Chi-Square tests this is  */
 /* equivlent to a gaussian contraint.                                                          */
+/* If a second width is given, asymmetric errors are used.                                     */
 /***********************************************************************************************/
 #ifndef __OXSX_QUADRATIC_CONSTRAINT__
 #define __OXSX_QUADRATIC_CONSTRAINT__
@@ -24,7 +25,7 @@ class QuadraticConstraint{
     
  private:
     double fMean;
-    double fWidth;
+    double fWidth; //Used as both symmetric width, or asymmetric upper width. 
     double fWidth_lo;
     bool is_asym;
 };

--- a/test/unit/BinnedNLLHTest.cpp
+++ b/test/unit/BinnedNLLHTest.cpp
@@ -66,4 +66,32 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         lh.SetParameters(params);
         REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + constraint));
     }
+    SECTION("Correct Probability with asymmetric constraint"){
+        lh.SetConstraint("b", 5, 1, 2);
+
+        double sumLogProb = -log(prob1 + prob2 + prob3);
+        double sumNorm    = 3;
+        double constraint = 2;
+
+        ParameterDict params;
+        params["a"] = 1;
+        params["b"] = 1;
+        params["c"] = 1;
+        lh.SetParameters(params);
+        REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + constraint));
+    }
+    SECTION("Correct Probability with asymmetric constraint 2"){
+        lh.SetConstraint("b", -3, 1, 2);
+
+        double sumLogProb = -log(prob1 + prob2 + prob3);
+        double sumNorm    = 3;
+        double constraint = 8;
+
+        ParameterDict params;
+        params["a"] = 1;
+        params["b"] = 1;
+        params["c"] = 1;
+        lh.SetParameters(params);
+        REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + constraint));
+    }
 }


### PR DESCRIPTION
Currently, only symmetric constraints are possible for the `BinnedNLLH` class. This is an issue, given that some constraints we need to enforce in analyses (such as the solar flux constraint) are asymmetric.

This simple PR adds functionality to the `QuadraticConstraint` class so that either symmetric _or_ asymmetric constraints can be used, with a new associated constructor overload. If you want symmetric errors, just provide the mean and width, and for asymmetric errors provide the mean and two widths.

The `QuadraticConstraint` class is used mainly by the `BinnedNLLH` class; a similar function overload has been added there for the `SetConstraint()` method.

This modification has been designed so that existing code should function identically to how it did before with no changes needed.

I have also added two unit tests that demonstrate the asymmetric constraint working in action. 