### PR TITLE
Feature syst speed

### DIFF
--- a/src/fitutil/BinnedEDShrinker.cpp
+++ b/src/fitutil/BinnedEDShrinker.cpp
@@ -103,7 +103,7 @@ BinnedEDShrinker::SetBinMap(const BinnedED& dist_ ) {
 	  fUseContent.at(i) = false;
       }
       // bins in the upper buffer have i > number of bins in axis j. Do the same
-      if (offsetIndex >= fNewAxes.GetAxis(j).GetNBins()){
+      if ((unsigned)offsetIndex >= fNewAxes.GetAxis(j).GetNBins()){
         offsetIndex = fNewAxes.GetAxis(j).GetNBins() - 1;
 	// If not using overflows, flag this bin as not having it's contents included
 	if(!fUsingOverflows)

--- a/src/fitutil/BinnedEDShrinker.cpp
+++ b/src/fitutil/BinnedEDShrinker.cpp
@@ -54,77 +54,91 @@ BinnedEDShrinker::ShrinkAxis(const BinAxis& axis_, const unsigned lowerBuff_,
     return BinAxis(axis_.GetName(), lowEdges, highEdges, axis_.GetLatexName());
 }
 
+void
+BinnedEDShrinker::SetBinMap(const BinnedED& dist_ ) {
+
+  // No buffer no problem. FIXME: what about if all the values are zero?
+  if (!fBuffers.size())
+    return ;
+
+  size_t nDims = dist_.GetNDims();
+
+  // FIXME Add a check to see if the non zero entries of fBuffers are in the pdf and give warning
+
+  // 1. Build new axes. ShrinkPdf method just makes a copy if buffer size is zero
+  
+  for(size_t i = 0; i < nDims; i++){
+    const std::string& axisName = dist_.GetAxes().GetAxis(i).GetName();
+    if (!fBuffers.count(axisName))
+      fNewAxes.AddAxis(dist_.GetAxes().GetAxis(i));
+    else
+      fNewAxes.AddAxis(ShrinkAxis(dist_.GetAxes().GetAxis(i),
+				 fBuffers.at(axisName).first,
+				 fBuffers.at(axisName).second));
+  }
+
+  // 2. Find corresponding bins
+  std::vector<size_t> newIndices(dist_.GetNDims());  // same as old, just corrected for overflow
+  int   offsetIndex = 0; // note taking difference of two unsigneds
+  size_t newBin = 0;     //  will loop over dims and use this to assign bin # corrected for overflow
+
+  const AxisCollection& axes = dist_.GetAxes();
+
+  // bin by bin of old pdf
+  for(size_t i = 0; i < dist_.GetNBins(); i++){
+
+    // work out the index of this bin in the new shrunk pdf.
+    for(size_t j = 0; j < nDims; j++){
+      std::string axisName = axes.GetAxis(j).GetName();
+      offsetIndex = axes.UnflattenIndex(i, j);            // the index in old pdf
+      if (fBuffers.count(axisName))          // offset by lower buffer if nonzero
+	offsetIndex -= fBuffers.at(axisName).first;
+
+      // Correct the ones that fall in the buffer regions
+      // bins in the lower buffer have negative index. Put in first bin in fit region or ignore
+      if (offsetIndex < 0){
+	offsetIndex = 0;
+      }
+      // bins in the upper buffer have i > number of bins in axis j. Do the same
+      if (offsetIndex >= fNewAxes.GetAxis(j).GetNBins()){
+	offsetIndex = fNewAxes.GetAxis(j).GetNBins() - 1;
+      }
+
+      newIndices[j] = offsetIndex;
+    }
+    // Fill
+    newBin = fNewAxes.FlattenIndices(newIndices);
+    fBinVec.push_back(newBin);
+  }
+} 
+
 BinnedED
 BinnedEDShrinker::ShrinkDist(const BinnedED& dist_) const{
 
     // No buffer no problem. FIXME: what about if all the values are zero?
     if (!fBuffers.size())
         return dist_;
-    
-    size_t nDims = dist_.GetNDims();
 
-    // FIXME Add a check to see if the non zero entries of fBuffers are in the pdf and give warning
+    // Initialise the new pdf with same observables
 
-    // 1. Build new axes. ShrinkPdf method just makes a copy if buffer size is zero
-    AxisCollection newAxes;
-    for(size_t i = 0; i < nDims; i++){
-        const std::string& axisName = dist_.GetAxes().GetAxis(i).GetName();
-        if (!fBuffers.count(axisName))
-            newAxes.AddAxis(dist_.GetAxes().GetAxis(i));
-        else
-            newAxes.AddAxis(ShrinkAxis(dist_.GetAxes().GetAxis(i),
-                                       fBuffers.at(axisName).first,
-                                       fBuffers.at(axisName).second));
-    }
-
-    // 2. Initialise the new pdf with same observables
-    BinnedED newDist(dist_.GetName() + "_shrunk", newAxes);
+    BinnedED newDist(dist_.GetName() + "_shrunk", fNewAxes);
     newDist.SetObservables(dist_.GetObservables());
+    
 
-    // 3. Fill the axes
-    std::vector<size_t> newIndices(dist_.GetNDims());  // same as old, just corrected for overflow
-    int   offsetIndex = 0; // note taking difference of two unsigneds
+    // Fill the axes
     size_t newBin = 0;     //  will loop over dims and use this to assign bin # corrected for overflow
-
-    const AxisCollection& axes = dist_.GetAxes();
     double content = 0;
-    // bin by bin of old pdf
+    
+    // bin by bin of old pdf    
     for(size_t i = 0; i < dist_.GetNBins(); i++){
-        content = dist_.GetBinContent(i);
-        if(!content) // no content no problem
-            continue;
 
-        // work out the index of this bin in the new shrunk pdf.
-        for(size_t j = 0; j < nDims; j++){
-            std::string axisName = axes.GetAxis(j).GetName();
-            offsetIndex = axes.UnflattenIndex(i, j);            // the index in old pdf
-            if (fBuffers.count(axisName))          // offset by lower buffer if nonzero
-                offsetIndex -= fBuffers.at(axisName).first;
+      content = dist_.GetBinContent(i);
+      if(!content) // no content no problem
+	continue;
 
-            // Correct the ones that fall in the buffer regions
-            // bins in the lower buffer have negative index. Put in first bin in fit region or ignore
-            if (offsetIndex < 0){
-                offsetIndex = 0;
-                if(!fUsingOverflows)
-                    content = 0;
-
-            }
-
-            // bins in the upper buffer have i > number of bins in axis j. Do the same
-            if (offsetIndex >= static_cast<int>(newAxes.GetAxis(j).GetNBins())){
-                offsetIndex = newAxes.GetAxis(j).GetNBins() - 1;
-
-                if (!fUsingOverflows)
-                    content = 0;
-            }
-
-            newIndices[j] = offsetIndex;
-        }
-        // Fill 
-        newBin = newAxes.FlattenIndices(newIndices);
-        newDist.AddBinContent(newBin, content);
-    }
-
+      newBin = fBinVec.at(i);
+      newDist.AddBinContent(newBin, content);
+      }
     return newDist;
 }
 

--- a/src/fitutil/BinnedEDShrinker.cpp
+++ b/src/fitutil/BinnedEDShrinker.cpp
@@ -86,7 +86,7 @@ BinnedEDShrinker::SetBinMap(const BinnedED& dist_ ) {
 
   // bin by bin of old pdf
   for(size_t i = 0; i < dist_.GetNBins(); i++){
-
+    fUseContent.push_back(true);
     // work out the index of this bin in the new shrunk pdf.
     for(size_t j = 0; j < nDims; j++){
       std::string axisName = axes.GetAxis(j).GetName();
@@ -98,10 +98,16 @@ BinnedEDShrinker::SetBinMap(const BinnedED& dist_ ) {
       // bins in the lower buffer have negative index. Put in first bin in fit region or ignore
       if (offsetIndex < 0){
 	offsetIndex = 0;
+	// If not using overflows, flag this bin as not having it's contents included
+	if(!fUsingOverflows)
+	  fUseContent.at(i) = false;
       }
       // bins in the upper buffer have i > number of bins in axis j. Do the same
       if (offsetIndex >= fNewAxes.GetAxis(j).GetNBins()){
-	offsetIndex = fNewAxes.GetAxis(j).GetNBins() - 1;
+        offsetIndex = fNewAxes.GetAxis(j).GetNBins() - 1;
+	// If not using overflows, flag this bin as not having it's contents included
+	if(!fUsingOverflows)
+	  fUseContent.at(i) = false;
       }
 
       newIndices[j] = offsetIndex;
@@ -137,7 +143,9 @@ BinnedEDShrinker::ShrinkDist(const BinnedED& dist_) const{
 	continue;
 
       newBin = fBinVec.at(i);
-      newDist.AddBinContent(newBin, content);
+      // Check if binn has been flagged to not use it's content
+      if(fUseContent.at(i))
+	newDist.AddBinContent(newBin, content);
       }
     return newDist;
 }

--- a/src/fitutil/BinnedEDShrinker.h
+++ b/src/fitutil/BinnedEDShrinker.h
@@ -20,6 +20,7 @@ class BinnedEDShrinker{
                        const unsigned upperBuff_) const;
     BinnedED ShrinkDist(const BinnedED& dist_) const;
     
+    void SetBinMap(const BinnedED& dist_);
     void SetBuffer(const std::string& dim_, unsigned lowerBuf_, unsigned upperBuf_);
     std::pair<unsigned, unsigned> GetBuffer(const std::string&) const;
     
@@ -30,7 +31,10 @@ class BinnedEDShrinker{
 
  private:
     // Pairs of lower/upper buffer sizes in number of bins, keyed by diminension to shrink
-    std::map<std::string, std::pair<unsigned, unsigned> > fBuffers; 
+    std::map<std::string, std::pair<unsigned, unsigned> > fBuffers;
+    std::vector<int> fBinVec;
     bool fUsingOverflows; // false at initialisation
+    AxisCollection fNewAxes;
+
 };
 #endif

--- a/src/fitutil/BinnedEDShrinker.h
+++ b/src/fitutil/BinnedEDShrinker.h
@@ -33,6 +33,7 @@ class BinnedEDShrinker{
     // Pairs of lower/upper buffer sizes in number of bins, keyed by diminension to shrink
     std::map<std::string, std::pair<unsigned, unsigned> > fBuffers;
     std::vector<int> fBinVec;
+    std::vector<int> fUseContent; // Use content from this bin after shrinking? False for bins in buffer region if fUsingOverflows is false
     bool fUsingOverflows; // false at initialisation
     AxisCollection fNewAxes;
 

--- a/src/optimise/MCMCSamples.cpp
+++ b/src/optimise/MCMCSamples.cpp
@@ -143,8 +143,8 @@ MCMCSamples::Fill(const ParameterDict& params_, double val_, bool accepted_){
     if(fSaveChain){
         int parameterNumber = 0;
         for( ParameterDict::const_iterator it = params_.begin(); it != params_.end(); ++it){
-	parvals[parameterNumber] = it->second;
-	parameterNumber++;
+	  parvals[parameterNumber] = it->second;
+	  parameterNumber++;
         }
         fCurrentVal = val_;
         fStepNumber = fTotalSteps;

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -49,7 +49,6 @@ BinnedNLLH::Evaluate(){
     for(const auto& constraint: fConstraints) {
         nLogLH += constraint.second.Evaluate(fComponentManager.GetParameter(constraint.first));
     }
-
     return nLogLH;
 }
 

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -18,13 +18,12 @@ BinnedNLLH::Evaluate(){
         BinData();
     
     if(!fAlreadyShrunk){
-        fDataDist = fPdfShrinker.ShrinkDist(fDataDist);
+        fPdfShrinker.SetBinMap(fDataDist);
+        fDataDist = fPdfShrinker.ShrinkDist(fDataDist);	
         fAlreadyShrunk = true;
     }
 
-
-    // Construct systematics 
-    fSystematicManager.Construct(); 
+    fSystematicManager.Construct();
     // Apply systematics
     fPdfManager.ApplySystematics(fSystematicManager);
 
@@ -45,11 +44,12 @@ BinnedNLLH::Evaluate(){
     // Extended LH correction
     const std::vector<double>& normalisations = fPdfManager.GetNormalisations();
     for(const auto& normalisation: normalisations) { nLogLH += normalisation; }
-            
+
     // Constraints
     for(const auto& constraint: fConstraints) {
         nLogLH += constraint.second.Evaluate(fComponentManager.GetParameter(constraint.first));
     }
+
     return nLogLH;
 }
 

--- a/test/unit/BinnedEDShrinkerTest.cpp
+++ b/test/unit/BinnedEDShrinkerTest.cpp
@@ -43,7 +43,9 @@ TEST_CASE("Shrinking a 1D pdf"){
     SECTION("With overflow bins"){
         shrinker.SetUsingOverflows(true);
 
+        shrinker.SetBinMap(inputDist);
         BinnedED shrunkPdf = shrinker.ShrinkDist(inputDist);
+
         REQUIRE(shrunkPdf.GetNBins() == inputDist.GetNBins() - 5 - 3);
 
         // check the over flow bins and the middle bin
@@ -52,11 +54,12 @@ TEST_CASE("Shrinking a 1D pdf"){
         // 94 is already there, then add 99, 98, 97, 96, 95 buffer bins = 579
         REQUIRE(shrunkPdf.GetBinContent(shrunkPdf.GetNBins() - 1) == 579); 
         REQUIRE(shrunkPdf.GetBinContent(50) == 53); // just gets offset by 3
-       
+
     }
     
     SECTION("With truncation"){
         shrinker.SetUsingOverflows(false);
+        shrinker.SetBinMap(inputDist);
         BinnedED shrunkPdf = shrinker.ShrinkDist(inputDist);
         REQUIRE(shrunkPdf.GetNBins() == inputDist.GetNBins() - 5 - 3);
 
@@ -94,6 +97,7 @@ TEST_CASE("2D pdf, only have buffer in one direction"){
     
     SECTION("With Overflow bins"){
         shrinker.SetUsingOverflows(true);
+        shrinker.SetBinMap(inputDist);
         BinnedED shrunk = shrinker.ShrinkDist(inputDist);
 
         REQUIRE(shrunk.GetAxes().GetAxis(0).GetNBins() == inputDist.GetAxes().GetAxis(0).GetNBins());


### PR DESCRIPTION
This PR is designed to speed up the calculation of the LLH when using systematics. The BinnedEdShrinker is used to take out the buffer region and reassign bin numbers. Previously, the reassigning of bin numbers happened everytime the LLH was evaluated. This PR introduces a SetBinMap function which is only called the first time the shrinker is called. It then saves the corresponding bin numbers in a vector (fBinVec) to avoid having to do the nested loop of old and new bins (unshrunk and shrunk) every time.

Most of it is just moving code from BinnedEDShrinker::ShrinkDist to SetBinMap, so it looks like more has changed than it has really.

Bar any coding typos, I think the logic works unless there's some situation where the buffer would change during a fit, but maybe there's something I've not thought of?

I have been using it for a while with the double beta fits and haven't seen any problems, but it would be good to get a second pair of eyes to take a look at it.