### PR TITLE
add shift class of systematic

### DIFF
--- a/src/systematic/Shift.cpp
+++ b/src/systematic/Shift.cpp
@@ -1,0 +1,147 @@
+#include <Shift.h>
+#include <sstream>
+#include <DoubleParameter.h>
+#include <Exceptions.h>
+#include <ContainerTools.hpp>
+
+void 
+Shift::Construct(){
+    
+    if(fTransObs.GetNObservables() != 1)
+        throw RepresentationError("Shift systematic must have a 1D representation!");
+
+    const AxisCollection& axes       = fAxes;
+    // the axis to shift
+    const std::string&  shiftAxisName = fTransObs.GetNames().at(0);
+    const BinAxis& shiftAxis          = axes.GetAxis(fDistObs.GetIndex(shiftAxisName));
+
+    const size_t nBins               = axes.GetNBins(); 
+    const size_t shiftAxisNBins      = shiftAxis.GetNBins(); 
+ 
+    for(size_t i = 0; i < nBins; i++){
+        // For each old bin, work out the contributions into all of the new bins
+        // indices in other components should be unaffected
+        std::vector<size_t> oldIndices = axes.UnpackIndices(i);
+        size_t shiftBin                = oldIndices.at(fDistObs.GetIndex(shiftAxisName));
+        
+        double shiftedLow   = shiftAxis.GetBinLowEdge(shiftBin)  + fShift;
+        double shiftedHigh  = shiftAxis.GetBinHighEdge(shiftBin) + fShift;
+        double shiftedWidth = shiftedHigh - shiftedLow;
+
+        // new bin to map into, mapping only happens if the indices are the same except the one to 
+        // shift so, loop over the bins in the shift axes and leave other indices the same
+        // the others are zero from initialisation 
+        
+        std::vector<size_t> newIndices = oldIndices;
+        for(size_t j = 0; j < shiftAxisNBins; j++){
+            newIndices[fDistObs.GetIndex(shiftAxisName)] = j;
+            size_t newShiftBin = j;
+                        
+            double newLow  = shiftAxis.GetBinLowEdge(newShiftBin);
+            double newHigh = shiftAxis.GetBinHighEdge(newShiftBin);
+
+            double contribution;
+            // Is it in the shift region at all?
+            if (newLow > shiftedHigh || newHigh < shiftedLow) 
+                contribution = 0;
+
+            else{
+                // Is it fully in the region?
+                bool includedFromBelow = newLow > shiftedLow;
+                bool includedFromAbove = newHigh < shiftedHigh;
+
+                if (includedFromBelow && includedFromAbove) 
+		    // fully inside
+		    contribution = (newHigh - newLow)/shiftedWidth;
+
+                else if (includedFromBelow) 
+                    // spills partly over the top
+                    contribution = (shiftedHigh - newLow)/shiftedWidth;
+
+                else 
+                    // spills partly over the bottom
+                    contribution = (newHigh - shiftedLow)/shiftedWidth;
+            }
+
+            fResponse.SetComponent(axes.FlattenIndices(newIndices), i, contribution);
+        }
+               
+    }
+    return;
+}
+
+void
+Shift::SetShift(double shift_){
+    fShift = shift_;
+}
+
+double
+Shift::GetShift() const{
+    return fShift;
+}
+
+
+//////////////////////////////////////////////////////////////////
+// Make this object fittable, so the shift is adjustable //
+//////////////////////////////////////////////////////////////////
+
+void
+Shift::SetParameter(const std::string& name_, double value){
+    if(name_ != fParamName)
+        throw ParameterError("Shift: can't set " + name_ + ", " + fParamName + " is the only parameter" );
+    fShift = value;
+}
+
+double
+Shift::GetParameter(const std::string& name_) const{
+   if(name_ != fParamName)
+        throw ParameterError("Shift: can't get " + name_ + ", " + fParamName + " is the only parameter" );
+   return fShift;
+}
+
+void
+Shift::SetParameters(const ParameterDict& pd_){
+    try{
+        fShift = pd_.at(fParamName);
+    }
+    catch(const std::out_of_range& e_){
+        throw ParameterError("Set dictionary is missing " + fParamName + ". I did contain: \n" + ContainerTools::ToString(ContainerTools::GetKeys(pd_)));
+    }
+}
+
+ParameterDict
+Shift::GetParameters() const{
+    ParameterDict d;
+    d[fParamName] = fShift;
+    return d;
+}
+
+size_t
+Shift::GetParameterCount() const{
+    return 1;
+}
+
+std::set<std::string>
+Shift::GetParameterNames() const{
+    std::set<std::string> set;
+    set.insert(fParamName);
+    return set;
+}
+
+void
+Shift::RenameParameter(const std::string& old_, const std::string& new_){
+    if(old_ != fParamName)
+        throw ParameterError("Shift: can't rename " + old_ + ", " + fParamName + " is the only parameter" );
+    fParamName = new_;
+}
+
+std::string
+Shift::GetName() const{
+    return fName;
+}
+
+void
+Shift::SetName(const std::string& name_){
+    fName = name_;
+}
+

--- a/src/systematic/Shift.h
+++ b/src/systematic/Shift.h
@@ -1,0 +1,36 @@
+/*****************************************/
+/* A simple shift error on an observable */
+/*****************************************/
+#ifndef __OXSX_SHIFT__
+#define __OXSX_SHIFT__
+#include <Systematic.h>
+#include <string>
+
+class Shift : public Systematic{
+ public:
+    Shift(const std::string& name_) : fShift(1), fName(name_), fParamName("shift") {}
+    void   SetShift(double);
+    double GetShift() const;
+    
+    void Construct();
+
+    // Adjustable shift
+    void   SetParameter(const std::string& name_, double value);
+    double GetParameter(const std::string& name_) const;
+
+    void   SetParameters(const ParameterDict&);
+    ParameterDict GetParameters() const;
+    size_t GetParameterCount() const;
+
+    std::set<std::string> GetParameterNames() const;
+    void   RenameParameter(const std::string& old_, const std::string& new_);
+
+    std::string GetName() const;
+    void SetName(const std::string&);
+ 
+ private:
+    double      fShift;
+    std::string fName;
+    std::string fParamName;
+};
+#endif

--- a/test/unit/ScaleSystTest.cpp
+++ b/test/unit/ScaleSystTest.cpp
@@ -1,0 +1,48 @@
+#include <catch.hpp>
+#include <SystematicManager.h>
+#include <Scale.h>
+
+TEST_CASE("Simple scale systematic on 1d PDF"){
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis0", 0, 5, 5));
+    std::vector<std::string> observables;
+    observables.push_back("obs0");
+
+    BinnedED pdf1("pdf1", axes);
+    pdf1.SetBinContent(0, 0);
+    pdf1.SetBinContent(1, 10);
+    pdf1.SetBinContent(2, 0);
+    pdf1.SetBinContent(3, 0);
+    pdf1.SetBinContent(4, 0);
+    pdf1.SetObservables(observables);
+
+    Scale* scale = new Scale("scale");
+    scale->SetScaleFactor(2.0);
+    scale->SetAxes(axes);
+    scale->SetTransformationObs(observables);
+    scale->SetDistributionObs(observables);
+    scale->Construct();
+
+    SystematicManager man;
+    Systematic* syst1;
+    syst1 = scale;
+    man.Add(syst1);
+    man.AddDist(pdf1,"");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs;
+    pdfs.push_back(pdf1);
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs,pdfs);
+
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals;
+    correctVals.push_back(0);
+    correctVals.push_back(0);
+    correctVals.push_back(5);
+    correctVals.push_back(5);
+    correctVals.push_back(0);
+
+    REQUIRE(modifiedObs == correctVals);
+}

--- a/test/unit/ShiftSystTest.cpp
+++ b/test/unit/ShiftSystTest.cpp
@@ -1,0 +1,78 @@
+#include <catch.hpp>
+#include <SystematicManager.h>
+#include <Shift.h>
+
+TEST_CASE("Simple shift systematic on 1d PDF"){
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis0", 0, 5, 5));
+    std::vector<std::string> observables;
+    observables.push_back("obs0");
+
+    BinnedED pdf1("pdf1", axes);
+    pdf1.SetBinContent(0, 0);
+    pdf1.SetBinContent(1, 10);
+    pdf1.SetBinContent(2, 0);
+    pdf1.SetBinContent(3, 0);
+    pdf1.SetBinContent(4, 0);
+    pdf1.SetObservables(observables);
+
+    Shift* shift = new Shift("shift");
+    shift->SetShift(2.0);
+    shift->SetAxes(axes);
+    shift->SetTransformationObs(observables);
+    shift->SetDistributionObs(observables);
+    shift->Construct();
+
+    SystematicManager man;
+
+    SECTION("With shift == integer number of bins"){
+
+      Systematic* syst1;
+      syst1 = shift;
+      man.Add(syst1);
+      man.AddDist(pdf1,"");
+      man.Construct();
+      
+      std::vector<BinnedED> pdfs;
+      pdfs.push_back(pdf1);
+      std::vector<BinnedED> OrignalPdfs(pdfs);
+      
+      man.DistortEDs(OrignalPdfs,pdfs);
+      
+      std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+      std::vector<double> correctVals;
+      correctVals.push_back(0);
+      correctVals.push_back(0);
+      correctVals.push_back(0);
+      correctVals.push_back(10);
+      correctVals.push_back(0);
+      
+      REQUIRE(modifiedObs == correctVals);
+    }
+    
+    SECTION("With shift == non-integer number of bins"){
+      
+      shift->SetShift(1.5);
+      Systematic* syst1;
+      syst1 = shift;
+      man.Add(syst1);
+      man.AddDist(pdf1,"");
+      man.Construct();
+
+      std::vector<BinnedED> pdfs;
+      pdfs.push_back(pdf1);
+      std::vector<BinnedED> OrignalPdfs(pdfs);
+
+      man.DistortEDs(OrignalPdfs,pdfs);
+
+      std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+      std::vector<double> correctVals;
+      correctVals.push_back(0);
+      correctVals.push_back(0);
+      correctVals.push_back(5);
+      correctVals.push_back(5);
+      correctVals.push_back(0);
+
+      REQUIRE(modifiedObs == correctVals);
+    }
+}


### PR DESCRIPTION
This adds a 'Shift' type of systematic, whereby a bin-by-bin shift can be applied in a given variable. This essentially used Scale as a template and did an add instead of a multiply. 

I've been using it for a bit and haven't seen any issues, but there's a bit of fiddly logic when determining what fraction of a bin's contents will be shifted into which bin, so fresh eyes on that in particular will be handy!