### PR TITLE
Add shape systematic

### DIFF
--- a/src/fitutil/BinnedEDManager.cpp
+++ b/src/fitutil/BinnedEDManager.cpp
@@ -23,7 +23,13 @@ BinnedEDManager::Probability(const Event& data_) {
     double sum = 0;
 
     for(size_t i = 0; i < fWorkingPdfs.size(); i++){
-        sum += fNormalisations.at(i) * fWorkingPdfs[i].Probability(data_);
+        if (fAllowNormsFittable.at(i)) {
+            sum += fNormalisations.at(i) * fWorkingPdfs[i].Probability(data_);
+        } else {
+            // In case where we don't auto-normalise the pdf,
+            // the normalisation is held within the pdf itself!
+            sum += fWorkingPdfs.at(i).Probability(data_);
+        }
     }
 
     return sum;
@@ -37,7 +43,13 @@ BinnedEDManager::BinProbability(size_t bin_) {
     double sum = 0;
     try{
         for(size_t i = 0; i < fWorkingPdfs.size(); i++){
-            sum += fNormalisations.at(i) * fWorkingPdfs.at(i).GetBinContent(bin_);
+            if (fAllowNormsFittable.at(i)) {
+                sum += fNormalisations.at(i) * fWorkingPdfs.at(i).GetBinContent(bin_);
+            } else {
+                // In case where we don't auto-normalise the pdf,
+                // the normalisation is held within the pdf itself!
+                sum += fWorkingPdfs.at(i).GetBinContent(bin_);
+            }
         }
     }
     catch(const std::out_of_range&){
@@ -95,7 +107,7 @@ void
 BinnedEDManager::AddPdfs(const std::vector<BinnedED>& pdfs_,
                          const std::vector<bool>* norms_fittable){
     if(norms_fittable != nullptr && pdfs_.size() != norms_fittable->size()) {
-        throw LogicError("BinnedEDManager: number of norm_fittable bools doesn't the number of pdfs");
+        throw DimensionError("BinnedEDManager: number of norm_fittable bools doesn't the number of pdfs");
     }
 
     for(size_t i = 0; i < pdfs_.size(); i++){

--- a/src/fitutil/BinnedEDManager.cpp
+++ b/src/fitutil/BinnedEDManager.cpp
@@ -80,7 +80,7 @@ BinnedEDManager::ApplySystematics(const SystematicManager& sysMan_){
         sysMan_.DistortEDs(fOriginalPdfs,fWorkingPdfs, &norms);
         for (size_t i = 0; i < norms.size(); i++) {
             if (!fAllowNormsFittable.at(i)) {
-                fNormalisations[i] *= norms.at(i);
+                fNormalisations[i] = norms.at(i);
             }
         }
     }

--- a/src/fitutil/BinnedEDManager.h
+++ b/src/fitutil/BinnedEDManager.h
@@ -14,13 +14,14 @@ class SystematicManager;
 class BinnedEDShrinker;
 class BinnedEDManager : public FitComponent{
  public:
-    BinnedEDManager() : fNPdfs(0), fName("norms") {}
+    BinnedEDManager() : fAllNormsFittable(true), fNPdfs(0), fName("norms") {}
 
-    void   AddPdf(const BinnedED&);
-    void   AddPdfs(const std::vector<BinnedED>&);
+    void   AddPdf(const BinnedED&, const bool norm_fittable=true);
+    void   AddPdfs(const std::vector<BinnedED>&,
+                   const std::vector<bool>* norms_fittable=nullptr);
 
-    double Probability(const Event&) const;
-    double BinProbability(size_t) const;
+    double Probability(const Event&);
+    double BinProbability(size_t);
     
     const std::vector<double>& GetNormalisations() const;
     void SetNormalisations(const std::vector<double>& normalisations_);
@@ -53,11 +54,15 @@ class BinnedEDManager : public FitComponent{
     std::vector<BinnedED>  fOriginalPdfs;
     std::vector<BinnedED>  fWorkingPdfs;
     std::vector<double>    fNormalisations;
+    std::vector<bool>      fAllowNormsFittable;
+    std::vector<double>    fFittableNorms;
+    bool                   fAllNormsFittable;
     int                    fNPdfs;
     size_t fNDims;
 
     std::string fName; // component name
 
     void RegisterParameters();
+    void ReassertNorms();
 };
 #endif

--- a/src/fitutil/SystematicManager.cpp
+++ b/src/fitutil/SystematicManager.cpp
@@ -141,7 +141,9 @@ SystematicManager::AddDist(const BinnedED& pdf, const std::string& syss_){
 }
 
 void
-SystematicManager::DistortEDs(std::vector<BinnedED>& OrignalEDs_,std::vector<BinnedED>& WorkingEDs_) const {
+SystematicManager::DistortEDs(const std::vector<BinnedED>& OrignalEDs_,
+                              std::vector<BinnedED>& WorkingEDs_,
+                              std::vector<double>* norms) const {
     for(size_t j = 0; j < WorkingEDs_.size(); j++){
         const std::string name = OrignalEDs_.at(j).GetName();
 
@@ -185,6 +187,9 @@ SystematicManager::DistortEDs(std::vector<BinnedED>& OrignalEDs_,std::vector<Bin
               WorkingEDs_[j].SetBinContents(
                   GetTotalResponse(groupName).operator()(OrignalEDs_.at(j).GetBinContents()));
             }
+        }
+        if (norms != nullptr) {
+            norms->operator[](j) = WorkingEDs_.at(j).Integral();
         }
     }
 }

--- a/src/fitutil/SystematicManager.h
+++ b/src/fitutil/SystematicManager.h
@@ -50,7 +50,9 @@ class SystematicManager{
 
     const SparseMatrix& GetTotalResponse(const std::string& groupName_ = "" ) const;
 
-    void DistortEDs(std::vector<BinnedED>& OrigEDs,std::vector<BinnedED>& WorkingEDs) const;
+    void DistortEDs(const std::vector<BinnedED>& OrigEDs,
+                    std::vector<BinnedED>& WorkingEDs,
+                    std::vector<double>* norms=nullptr) const;
 
     void Construct();
     

--- a/src/systematic/Shape.cpp
+++ b/src/systematic/Shape.cpp
@@ -1,0 +1,68 @@
+#include <Shape.h>
+#include <Exceptions.h>
+
+void Shape::SetShapeFunction(ShapeFunction& shape_func,
+                             std::vector<std::string>& param_names) {
+    /*
+    * Setter for the shape function object; also the only way to add parameters
+    * into the parameter dict: the FitComponent interface allows one to set 
+    * values or rename params, but not add params.
+    */
+   fShapeFunc = shape_func;
+   // Clear any existing param stuff, then add param names with default values
+   fParamDict.clear();
+   for (auto &&param : param_names) {
+       fParamDict[param] = 0;
+   }
+}
+
+void Shape::Construct() {
+    /*
+    * 
+    */
+}
+
+// FitComponent interface: handling systematic's parameters
+// Note that once the parameter names have been set in SetShapeFunction(),
+// The number of parameters cannot be changed with this interface.
+// You can change the values and names of these parameters
+
+void
+Shape::SetParameter(const std::string& name_, double value){
+    if(fParamDict.count(name_) == 0)
+        throw ParameterError("Shift: can't set " + name_);
+    fParamDict[name_] = value;
+}
+
+double
+Shape::GetParameter(const std::string& name_) const{
+   if(fParamDict.count(name_) == 0)
+        throw ParameterError("Shift: can't set " + name_);
+    return fParamDict.at(name_);
+}
+
+void
+Shape::SetParameters(const ParameterDict& pd_){
+    try{
+        fScaleFactor = pd_.at(fParamName);
+    }
+    catch(const std::out_of_range& e_){
+        throw ParameterError("Set dictionary is missing " + fParamName + ". I did contain: \n" + ContainerTools::ToString(ContainerTools::GetKeys(pd_)));
+    }
+}
+
+std::set<std::string>
+Shape::GetParameterNames() const {
+    std::set<std::string> set;
+    for (auto &&pair : fParamDict) {
+        set.insert(pair.first);
+    }
+    return set;
+}
+
+void
+Shape::RenameParameter(const std::string& old_, const std::string& new_){
+    if(old_ != fParamName)
+        throw ParameterError("Scale: can't rename " + old_ + ", " + fParamName + " is the only parameter" );
+    fParamName = new_;
+}

--- a/src/systematic/Shape.cpp
+++ b/src/systematic/Shape.cpp
@@ -1,8 +1,8 @@
 #include <Shape.h>
 #include <Exceptions.h>
 
-void Shape::SetShapeFunction(ShapeFunction& shape_func,
-                             std::vector<std::string>& param_names) {
+void Shape::SetShapeFunction(const ShapeFunction& shape_func,
+                             const std::vector<std::string>& param_names) {
     /*
     * Setter for the shape function object; also the only way to add parameters
     * into the parameter dict: the FitComponent interface allows one to set 

--- a/src/systematic/Shape.cpp
+++ b/src/systematic/Shape.cpp
@@ -29,7 +29,7 @@ void Shape::Construct() {
     // If haven't already, generate mapping from full pdf bin IDs
     //--> transforming subspace bin IDs 
     if (!fCachedBinMapping) { CacheBinMapping(); }
-    // Loop over bins in the transforation subspace, and get the user-defined 
+    // Loop over bins in the transformation subspace, and get the user-defined 
     // shape scale factors at each bin centre.
     std::vector<double> bin_centres(fTransAxes.GetNDimensions());
     std::vector<double> shape_vals;
@@ -42,7 +42,7 @@ void Shape::Construct() {
             throw ValueError("User-defined shape function returned negative value: "
                                 + std::to_string(scale));
         }
-        shape_vals[bin] = scale;
+        shape_vals.push_back(scale);
     }
 
     // Finally, construct the full response matrix by setting the diagonal

--- a/src/systematic/Shape.cpp
+++ b/src/systematic/Shape.cpp
@@ -8,18 +8,49 @@ void Shape::SetShapeFunction(ShapeFunction& shape_func,
     * into the parameter dict: the FitComponent interface allows one to set 
     * values or rename params, but not add params.
     */
-   fShapeFunc = shape_func;
-   // Clear any existing param stuff, then add param names with default values
-   fParamDict.clear();
-   for (auto &&param : param_names) {
-       fParamDict[param] = 0;
-   }
+    fShapeFunc = shape_func;
+    // Clear any existing param stuff, then add param names with default values
+    fParamDict.clear();
+    for (auto &&param : param_names) {
+        fParamDict[param] = 0;
+    }
 }
 
 void Shape::Construct() {
     /*
-    * 
+    * Construct the response matrix for this shape systematic, given the
+    * shape function given by the user.
+    * Because impact of this systematic is to scale each bin independently,
+    * the response matrix is just diagonal.
     */
+    if (!fShapeFunc || !fAxes.GetNBins()) {
+        throw LogicError("Shape::Construct(): Tried to construct response matrix without either a shape function defined, or an axis collection!");
+    }
+    // If haven't already, generate mapping from full pdf bin IDs
+    //--> transforming subspace bin IDs 
+    if (!fCachedBinMapping) { CacheBinMapping(); }
+    // Loop over bins in the transforation subspace, and get the user-defined 
+    // shape scale factors at each bin centre.
+    std::vector<double> bin_centres(fTransAxes.GetNDimensions());
+    std::vector<double> shape_vals;
+    shape_vals.reserve(fTransAxes.GetNBins());
+
+    for (size_t bin = 0; bin < fTransAxes.GetNBins(); bin++) {
+        fTransAxes.GetBinCentres(bin, bin_centres);
+        const double scale = fShapeFunc(fParamDict, bin_centres);
+        if (scale < 0) {
+            throw ValueError("User-defined shape function returned negative value: "
+                                + std::to_string(scale));
+        }
+        shape_vals[bin] = scale;
+    }
+
+    // Finally, construct the full response matrix by setting the diagonal
+    // elements to their appropriate value, using the bin ID mapping to help.
+    for (size_t obs_bin_id = 0; obs_bin_id < fAxes.GetNBins(); obs_bin_id++) {
+        fResponse.SetComponent(obs_bin_id, obs_bin_id,
+                               shape_vals.at(fDistTransBinMapping.at(obs_bin_id)));
+    }
 }
 
 // FitComponent interface: handling systematic's parameters
@@ -27,26 +58,23 @@ void Shape::Construct() {
 // The number of parameters cannot be changed with this interface.
 // You can change the values and names of these parameters
 
-void
-Shape::SetParameter(const std::string& name_, double value){
+void Shape::SetParameter(const std::string& name_, double value){
     if(fParamDict.count(name_) == 0)
         throw ParameterError("Shift: can't set " + name_);
     fParamDict[name_] = value;
 }
 
-double
-Shape::GetParameter(const std::string& name_) const{
-   if(fParamDict.count(name_) == 0)
-        throw ParameterError("Shift: parameter " + name_);
+double Shape::GetParameter(const std::string& name_) const{
+    if(fParamDict.count(name_) == 0)
+        throw ParameterError("Shift: parameter " + name_ + "does not exist");
     return fParamDict.at(name_);
 }
 
-void
-Shape::SetParameters(const ParameterDict& pd_){
+void Shape::SetParameters(const ParameterDict& pd_){
     for (auto &&pair : pd_) {
         try{ fParamDict[pair.first] = pair.second; }
         catch(const std::out_of_range& e_){
-            throw ParameterError("Shift: can't set");
+            throw ParameterError("Shift: cannot set parameter " + pair.first);
         }
     }   
 }
@@ -59,9 +87,38 @@ std::set<std::string> Shape::GetParameterNames() const {
     return set;
 }
 
-void
-Shape::RenameParameter(const std::string& old_, const std::string& new_){
-    if(old_ != fParamName)
-        throw ParameterError("Scale: can't rename " + old_ + ", " + fParamName + " is the only parameter" );
-    fParamName = new_;
+void Shape::RenameParameter(const std::string& old_, const std::string& new_){
+    if(fParamDict.count(old_) == 0)
+        throw ParameterError("Shift: can't rename " + old_);
+    fParamDict[new_] = fParamDict.at(old_);
+    fParamDict.erase(old_);
+}
+
+// PRIVATE METHODS
+
+void Shape::CacheBinMapping() {
+    /*
+    * Because this shape systematic might only require a subset of the
+    * observables to be defined, but still need to act on the whole event
+    * distribution, we need a way of mapping from the full event distribution
+    * to the subspace we actually want to calculate shape values over.
+    */
+    std::vector<size_t> relativeIndices = fTransObs.GetRelativeIndices(fDistObs);
+    const AxisCollection& axes = fAxes;
+
+    //  get the axes that this systematic will act on
+    fTransAxes = AxisCollection();
+    for(size_t i = 0; i < relativeIndices.size(); i++) {
+        fTransAxes.AddAxis(axes.GetAxis(relativeIndices.at(i)));
+    }
+    // cache the equivilent index in the binning system of the systematic
+    fDistTransBinMapping.resize(fAxes.GetNBins());
+    std::vector<size_t> sysIndices(relativeIndices.size(), 0);
+    for(size_t i = 0; i < axes.GetNBins(); i++) {
+        for(size_t dim = 0; dim < relativeIndices.size(); dim++) {
+            sysIndices[dim] = axes.UnflattenIndex(i, relativeIndices.at(dim));
+        }
+      fDistTransBinMapping[i] = fTransAxes.FlattenIndices(sysIndices);
+    }
+    fCachedBinMapping = true;
 }

--- a/src/systematic/Shape.cpp
+++ b/src/systematic/Shape.cpp
@@ -37,22 +37,21 @@ Shape::SetParameter(const std::string& name_, double value){
 double
 Shape::GetParameter(const std::string& name_) const{
    if(fParamDict.count(name_) == 0)
-        throw ParameterError("Shift: can't set " + name_);
+        throw ParameterError("Shift: parameter " + name_);
     return fParamDict.at(name_);
 }
 
 void
 Shape::SetParameters(const ParameterDict& pd_){
-    try{
-        fScaleFactor = pd_.at(fParamName);
-    }
-    catch(const std::out_of_range& e_){
-        throw ParameterError("Set dictionary is missing " + fParamName + ". I did contain: \n" + ContainerTools::ToString(ContainerTools::GetKeys(pd_)));
-    }
+    for (auto &&pair : pd_) {
+        try{ fParamDict[pair.first] = pair.second; }
+        catch(const std::out_of_range& e_){
+            throw ParameterError("Shift: can't set");
+        }
+    }   
 }
 
-std::set<std::string>
-Shape::GetParameterNames() const {
+std::set<std::string> Shape::GetParameterNames() const {
     std::set<std::string> set;
     for (auto &&pair : fParamDict) {
         set.insert(pair.first);

--- a/src/systematic/Shape.h
+++ b/src/systematic/Shape.h
@@ -19,7 +19,8 @@ typedef std::function<double(const ParameterDict&,
 
 class Shape : public Systematic{
 public:
-    Shape(const std::string& name_) : fShapeFunc(), fParamDict(), fName(name_) {}
+    Shape(const std::string& name_) : fShapeFunc(), fParamDict(), fName(name_),
+                                      fCachedBinMapping(false) {}
 
     void SetShapeFunction(ShapeFunction& shape_func, std::vector<std::string>& param_names);
 
@@ -42,6 +43,12 @@ private:
     ShapeFunction fShapeFunc;
     ParameterDict fParamDict;
     std::string fName;
+
+    AxisCollection fTransAxes;
+    std::vector<size_t> fDistTransBinMapping;
+    bool fCachedBinMapping;
+
+    void CacheBinMapping();
 };
 
 #endif

--- a/src/systematic/Shape.h
+++ b/src/systematic/Shape.h
@@ -1,0 +1,47 @@
+/****************************************************************/
+/* A systematic that applies an arbitrary shape bin-by-bin onto */
+/* an event distribution.                                       */
+/* This shape is user-provided, and scales each bin by a        */
+/* certain factor.                                              */
+/****************************************************************/
+#ifndef __OXSX_SHAPE__
+#define __OXSX_SHAPE__
+#include <Systematic.h>
+#include <functional>
+
+/*
+* Firstly, for my own sanity, create a typedef for a general function that
+* takes in parameters + point in an event distribution's space, and returns
+* a value: this is a "shape function".
+*/
+typedef std::function<double(const ParameterDict&,
+                         const std::vector<double>&)> ShapeFunction;
+
+class Shape : public Systematic{
+public:
+    Shape(const std::string& name_) : fShapeFunc(), fParamDict(), fName(name_) {}
+
+    void SetShapeFunction(ShapeFunction& shape_func, std::vector<std::string>& param_names);
+
+    void Construct();
+
+    // FitComponent interface: handling systematic's parameters
+    void   SetParameter(const std::string& name_, double value);
+    double GetParameter(const std::string& name_) const;
+
+    void   SetParameters(const ParameterDict&);
+    ParameterDict GetParameters() const { return fParamDict; }
+    size_t GetParameterCount() const { return fParamDict.size(); }
+
+    std::set<std::string> GetParameterNames() const;
+    void   RenameParameter(const std::string& old_, const std::string& new_);
+
+    std::string GetName() const { return fName; }
+    void SetName(const std::string& name_) { fName = name_; }
+private:
+    ShapeFunction fShapeFunc;
+    ParameterDict fParamDict;
+    std::string fName;
+};
+
+#endif

--- a/src/systematic/Shape.h
+++ b/src/systematic/Shape.h
@@ -22,7 +22,8 @@ public:
     Shape(const std::string& name_) : fShapeFunc(), fParamDict(), fName(name_),
                                       fCachedBinMapping(false) {}
 
-    void SetShapeFunction(ShapeFunction& shape_func, std::vector<std::string>& param_names);
+    void SetShapeFunction(const ShapeFunction& shape_func,
+                          const std::vector<std::string>& param_names);
 
     void Construct();
 

--- a/src/systematic/Systematic.cpp
+++ b/src/systematic/Systematic.cpp
@@ -4,11 +4,16 @@
 #include <iostream>
 
 BinnedED 
-Systematic::operator() (const BinnedED& pdf_) const{
+Systematic::operator() (const BinnedED& pdf_, double* norm) const{
     try{
         BinnedED afterSmear = pdf_;
         afterSmear.SetBinContents(fResponse(pdf_.GetBinContents()));
-        afterSmear.Normalise();
+        if (norm != nullptr) {
+            *norm = afterSmear.Integral();
+            afterSmear.Scale(1./(*norm));
+        } else {
+            afterSmear.Normalise();
+        }
         return afterSmear;
     }
     catch(const DimensionError& e_){

--- a/src/systematic/Systematic.h
+++ b/src/systematic/Systematic.h
@@ -21,7 +21,7 @@ class Systematic : public FitComponent{
     virtual ~Systematic()  {}
 
     BinnedED 
-    operator()(const BinnedED& pdf_) const;
+    operator()(const BinnedED& pdf_, double* norm=nullptr) const;
         
     void SetResponse(const SparseMatrix& responseMatrix_);
     const SparseMatrix& GetResponse() const;

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -20,7 +20,7 @@ class BinnedNLLH : public TestStatistic{
     void   SetPdfManager(const BinnedEDManager&);
     void   SetSystematicManager(const SystematicManager&);
 
-    void   AddPdf(const BinnedED&);
+    void   AddPdf(const BinnedED&, const bool norm_fittable=true);
     void   AddSystematic(Systematic* sys_);
     void   AddSystematic(Systematic* sys_, const std::string& group_ );
 
@@ -44,9 +44,9 @@ class BinnedNLLH : public TestStatistic{
     void SetBuffer(const std::string& dim_, unsigned lower_, unsigned upper_);
     std::pair<unsigned, unsigned> GetBuffer(const std::string& dim_) const;
 
-    void AddPdf(const BinnedED& pdf, const std::vector<std::string>& syss_);
-    void AddPdfs(const std::vector<BinnedED>& pdfs);
-    void AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& syss_);
+    void AddPdf(const BinnedED& pdf, const std::vector<std::string>& syss_, const bool norm_fittable=true);
+    void AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<bool>* norms_fittable=nullptr);
+    void AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& syss_, const std::vector<bool>* norms_fittable=nullptr);
 
     void SetBufferAsOverflow(bool b_); // true by default
     bool GetBufferAsOverflow() const;

--- a/test/unit/BinnedNLLHTest.cpp
+++ b/test/unit/BinnedNLLHTest.cpp
@@ -50,6 +50,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         params["b"] = 1;
         params["c"] = 1;
         lh.SetParameters(params);
+        REQUIRE(lh.GetParameters() == params);
         REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb));
     }
     SECTION("Correct Probability with constraint"){

--- a/test/unit/ShapeTest.cpp
+++ b/test/unit/ShapeTest.cpp
@@ -1,0 +1,45 @@
+#include <catch.hpp>
+#include <Shape.h>
+#include <ParameterDict.h>
+
+double linear_func(const ParameterDict& params, const std::vector<double>& obs_vals) {
+    /*
+    * Simple non-trivial function, linear in x:
+    * returns = a*x + b
+    */
+    return params.at("a") * obs_vals.at(0) + params.at("b");
+}
+
+TEST_CASE("Shape") {
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("x", -10, 10 ,50));
+    axes.AddAxis(BinAxis("y", 20, 50, 10));
+
+    ObsSet dist_obs(std::vector<std::string>({"x", "y"}));
+    ObsSet trans_obs("x");
+
+    const std::vector<std::string> shape_param_names {"a", "b"};
+
+    Shape shape_sys("shape_sys");
+    shape_sys.SetAxes(axes);
+    shape_sys.SetDistributionObs(dist_obs);
+    shape_sys.SetTransformationObs(trans_obs);
+    shape_sys.SetShapeFunction(linear_func, shape_param_names);
+
+    shape_sys.SetParameters({{"a", 1}, {"b", 1000}});
+
+    shape_sys.Construct();
+
+    SECTION("Check systematic name") {
+        REQUIRE( shape_sys.GetName() == "shape_sys" );
+    }
+
+    SECTION("Check observables used") {
+        REQUIRE( shape_sys.GetDistributionObs() == dist_obs );
+        REQUIRE( shape_sys.GetTransformationObs() == trans_obs );
+    }
+
+    SECTION("Check axes") {
+        REQUIRE( shape_sys.GetAxes() == axes );
+    }
+}


### PR DESCRIPTION
A new systematic is added to OXO: `Shape`. The user can provide an arbitrary function that returns a value given a set of relevant observable values as well as any number of shape parameters (given in a `ParameterDict`). The effect of the systematic on a `BinnedED` is to scale each bin independently by the value returned by the user's function.

Because the bins get scaled independently, the response matrix generated with `Construct()` is diagonal. This class supports a user function that is only a function of a subset of the observable parameters.

Example use-case: in a solar oscillation analysis, the observed solar neutrino spectrum shape changes as a function of the solar oscillation parameters, solar flux, as well as the observed reconstructed energy of the event. A function can be developed by the user that describes the survival probability as a function of (energy, osc params, solar flux), and fed into a `Shape` systematic object. This can then be applied to an MC pdf (`BinnedED` object) to modify the shape accordingly, even if this pdf contains other observables that don't impact the survival probability: the event position, for example.

A critical aspect of this systematic is that the user might want it to impact the observed overall normalisation of a given pdf: in the above example, above just changing the shape of the energy spectrum, the total rate of events observed will drop significantly due to neutrino oscillations. By default of course, the usual functionality of asserting normalisation of the pdf(s) impacted by this systematic is maintained - this is how all other systematics currently function. If however the user wants to allow the normalisation to be impacted, then this default functionality can be turned off. In particular, The `BinnedEDManager`, `SystematicManager`, and `BinnedNLLH` classes have all been modified to handle this possibility. If you want to have the normalisation controlled by the systematic and not modified directly as a fit parameter directly from the `BinnedEDManager` within `BinnedNLLH`, then when you do `BinnedNLLH::AddPdf()`, there is now an extra option to turn off the standard normalisation handling.

In the existing OXO code, the normalisations of MC PDFs within the `BinnedNLLH` class have two related functions: one is to monitor the actual normalisation of the PDF, so that the NLLH can actually be calculated correctly, and the other is to be modified directly as a fit parameter. With the `Shape` systematic, by turning off the `norm` option when you add the PDF to the `BinnedNLLH` object the first property is maintained (otherwise the `BinnedNLLH` wouldn't be able to calculate likelihoods correctly!), but the latter is turned off. If the second property was kept on, then you end up with the problem of having fit parameters in both the `BinnedEDManager` AND `SystematicManager` trying to modify the normalisation, leading to chaos!

Going back to our solar example, by setting `norm=false`, there is no longer a `FitParameter` for directly modifying the normalisation of the oscillated solar spectrum. Instead, this normalisation can be _indirectly_ modified by the systematic parameters: namely the solar flux and oscillation parameters! The actual normalisation value for the oscillated PDF after the systematic has been applied is still stored within the `BinnedEDManager`.

Even though I've mucked about with `BinnedNLLH` etc., hopefully functionality for existing code should be identical - if you never care about the shape systematic, then interacting with the `BinnedNLLH` class should be as before!

In addition to all of this, I have checked this new functionality with a new set of unit tests, found within `ShapeTest.cpp`. On top of the basic functionality, I also confirm that the interaction between the `Shape` systematic and the `BinnedNLLH` class is as I would want. This file also acts as kind of a tutorial, if someone wants to use this new systematic.

The code compiles, as well as the unit tests, and all the unit tests pass.