### PR TITLE
Changing some types to compile with armadillo

### DIFF
--- a/src/core/DenseMatrix.h
+++ b/src/core/DenseMatrix.h
@@ -9,7 +9,6 @@
 #ifndef __OXSX_DENSE_MATRIX__
 #define __OXSX_DENSE_MATRIX__
 #include <AxisCollection.h>
-#define ARMA_DONT_USE_CXX11
 #include <armadillo>
 class BinnedPhysDist;
 

--- a/src/core/SparseMatrix.cpp
+++ b/src/core/SparseMatrix.cpp
@@ -102,8 +102,8 @@ SparseMatrix::SetToIdentity(){
 
 // FIXME: unsigned vs. size_t
 void 
-SparseMatrix::SetComponents(const std::vector<unsigned>& rowIndices_,
-                          const std::vector<unsigned>& colIndices_,
+SparseMatrix::SetComponents(const std::vector<long long unsigned int>& rowIndices_,
+                          const std::vector<long long unsigned int>& colIndices_,
                           const std::vector<double>& values_){
     if(rowIndices_.size() != values_.size() || colIndices_.size() != values_.size())
         throw DimensionError("SparseMatrix::SetComponent() #values != #locations");

--- a/src/core/SparseMatrix.h
+++ b/src/core/SparseMatrix.h
@@ -22,8 +22,8 @@ class SparseMatrix{
     void   SetComponent(size_t row_, size_t column_, double val_);
     double GetComponent(size_t row_, size_t column_) const;
 
-    void   SetComponents(const std::vector<unsigned>& rowIndices_,
-                         const std::vector<unsigned>& colIndices_,
+    void   SetComponents(const std::vector<long long unsigned int>& rowIndices_,
+                         const std::vector<long long unsigned int>& colIndices_,
                        const std::vector<double>& values_);
 
     SparseMatrix operator*=(const SparseMatrix& other_);

--- a/src/core/SparseMatrix.h
+++ b/src/core/SparseMatrix.h
@@ -9,7 +9,6 @@
 #ifndef __OXSX_SPARSE_MATRIX__
 #define __OXSX_SPARSE_MATRIX__
 #include <AxisCollection.h>
-#define ARMA_DONT_USE_CXX11
 #include <armadillo>
 class BinnedPhysDist;
 

--- a/src/systematic/Convolution.cpp
+++ b/src/systematic/Convolution.cpp
@@ -38,12 +38,12 @@ Convolution::Construct(){
 
     DenseMatrix subMap(fSubMapAxes.GetNBins(), fSubMapAxes.GetNBins());
 
-    for (size_t origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++){
+    for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++){
         // get the centre of the bin. Need to offset by this for a convolution
         fSubMapAxes.GetBinCentres(origBin, binCentres);
 
         // loop over the bins it can be smeared into 
-        for(size_t destBin = 0; destBin < fSubMapAxes.GetNBins(); destBin++){
+        for(long long unsigned int destBin = 0; destBin < fSubMapAxes.GetNBins(); destBin++){
             fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
             fSubMapAxes.GetBinHighEdges(destBin, highEdges);
             
@@ -54,8 +54,8 @@ Convolution::Construct(){
     // Now expand to the full size matrix. Elements are zero by default
     // compatible bins are cached, values must match the smaller matrix above
     size_t destBin = -1;
-    std::vector<unsigned> nonZeroRowIndices;
-    std::vector<unsigned> nonZeroColIndices;
+    std::vector<long long unsigned int> nonZeroRowIndices;
+    std::vector<long long unsigned int> nonZeroColIndices;
     std::vector<double> values;
     nonZeroRowIndices.reserve(fCompatibleBins.at(0).size());
     nonZeroColIndices.reserve(fCompatibleBins.at(0).size());


### PR DESCRIPTION
It had been a while since I'd done anything with OXO before this week, but when I tried to compile I needed to make a couple of changes in the SparseMatrix class and the Convolution systematic that calls it, otherwise I got Armadillo errors at compilation.

I don't know if this is because our Armadillo install at Oxford has been updated? Or maybe it's something specific to my setup. But thought I'd see if anyone else had seen anything similar before digging into it too much? And a pull request was a simple way to show exactly what I needed to change.

So this shouldn't be merged (unless we understand it and it's not specific to my install/setup), but just wanted to open a discussion