### PR TITLE
fix bug in SetConstraint()

### DIFF
--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -190,7 +190,7 @@ BinnedNLLH::SetConstraint(const std::string& paramName_, double mean_, double si
 
 void
 BinnedNLLH::SetConstraint(const std::string& paramName_, double mean_, double sigma_lo_, double sigma_hi_) {
-    fConstraints[paramName_] = QuadraticConstraint(mean_, sigma_lo_, sigma_hi_);
+    fConstraints[paramName_] = QuadraticConstraint(mean_, sigma_hi_, sigma_lo_);
 }
 
 

--- a/test/unit/BinnedNLLHTest.cpp
+++ b/test/unit/BinnedNLLHTest.cpp
@@ -71,7 +71,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
 
         double sumLogProb = -log(prob1 + prob2 + prob3);
         double sumNorm    = 3;
-        double constraint = 2;
+        double constraint = 8;
 
         ParameterDict params;
         params["a"] = 1;
@@ -85,7 +85,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
 
         double sumLogProb = -log(prob1 + prob2 + prob3);
         double sumNorm    = 3;
-        double constraint = 8;
+        double constraint = 2;
 
         ParameterDict params;
         params["a"] = 1;


### PR DESCRIPTION
In creating the additional `QuadraticConstraint` overload to handle asymmetric errors, I foolishly put them in the wrong way round within the related  BinnedNLLH::SetConstraint() method.

This is just a quick one-line fix to resolve this issue!