### PR TITLE
Add a Debug option to BinnedNLLH class

### DIFF
--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -41,14 +41,30 @@ BinnedNLLH::Evaluate(){
             throw std::runtime_error(Formatter() << "BinnedNLLH::Encountered zero probability bin! #" << i);
         nLogLH -= fDataDist.GetBinContent(i) *  log(prob);        
     }
-
+    if (fDebugMode) {
+        std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
+        std::cout << "NLLH after summing over bins only: " << nLogLH << std::endl;
+        std::cout << "Normalisations: ";
+    }
     // Extended LH correction
     const std::vector<double>& normalisations = fPdfManager.GetNormalisations();
-    for(const auto& normalisation: normalisations) { nLogLH += normalisation; }
-            
+    for(const auto& normalisation: normalisations) {
+        nLogLH += normalisation;
+        if (fDebugMode) {
+            std::cout << normalisation << "\t";
+        }
+    }
+    if(fDebugMode) {
+        std::cout << "\nNLLH after adding normalisations: " << nLogLH << std::endl;
+    }
     // Constraints
     for(const auto& constraint: fConstraints) {
-        nLogLH += constraint.second.Evaluate(fComponentManager.GetParameter(constraint.first));
+        const double con = constraint.second.Evaluate(fComponentManager.GetParameter(constraint.first));
+        nLogLH += con;
+        if (fDebugMode) { std::cout << "constraint: " << con << "\t"; }
+    }
+    if (fDebugMode) {
+        std::cout << "\nTotal NLLH: " << nLogLH << "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
     }
     return nLogLH;
 }

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -41,7 +41,7 @@ BinnedNLLH::Evaluate(){
             throw std::runtime_error(Formatter() << "BinnedNLLH::Encountered zero probability bin! #" << i);
         nLogLH -= fDataDist.GetBinContent(i) *  log(prob);
         if (fDebugMode) {
-            std::cout << "Bin i, MC bin probability: " << prob << ", data bin probability: ";
+            std::cout << "Bin " << i << ", MC bin probability: " << prob << ", data bin probability: ";
             std::cout << fDataDist.GetBinContent(i) << std::endl;
         }
     }

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -32,6 +32,7 @@ BinnedNLLH::Evaluate(){
     fPdfManager.ApplyShrink(fPdfShrinker);
 
     // loop over bins and calculate the likelihood
+    if (fDebugMode) { std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"; }
     double nLogLH = 0;
     for(size_t i = 0; i < fDataDist.GetNBins(); i++){
         if(!fDataDist.GetBinContent(i))
@@ -39,10 +40,13 @@ BinnedNLLH::Evaluate(){
         double prob = fPdfManager.BinProbability(i);
         if(!prob)
             throw std::runtime_error(Formatter() << "BinnedNLLH::Encountered zero probability bin! #" << i);
-        nLogLH -= fDataDist.GetBinContent(i) *  log(prob);        
+        nLogLH -= fDataDist.GetBinContent(i) *  log(prob);
+        if (fDebugMode) {
+            std::cout << "Bin i, MC bin probability: " << prob << ", data bin probability: ";
+            std::cout << fDataDist.GetBinContent(i) << std::endl;
+        }
     }
     if (fDebugMode) {
-        std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
         std::cout << "NLLH after summing over bins only: " << nLogLH << std::endl;
         std::cout << "Normalisations: ";
     }

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -15,7 +15,7 @@
 class DataSet;
 class BinnedNLLH : public TestStatistic{
  public:
-    BinnedNLLH() : fDataSet(NULL), fSignalCutEfficiency(1), fCalculatedDataDist(false), fAlreadyShrunk(false) {}
+    BinnedNLLH() : fDataSet(NULL), fSignalCutEfficiency(1), fCalculatedDataDist(false), fAlreadyShrunk(false), fDebugMode(false) {}
 
     void   SetPdfManager(const BinnedEDManager&);
     void   SetSystematicManager(const SystematicManager&);
@@ -60,6 +60,9 @@ class BinnedNLLH : public TestStatistic{
     CutLog GetSignalCutLog() const;
     void   SetSignalCutLog(const CutLog&);
 
+    bool GetDebugMode() const { return fDebugMode; }
+    void SetDebugMode(bool mode) { fDebugMode = mode; }
+
     // Test statistic interface
     void RegisterFitComponents(); 
     void SetParameters(const ParameterDict&);
@@ -82,6 +85,8 @@ class BinnedNLLH : public TestStatistic{
     BinnedED         fDataDist;
     bool             fCalculatedDataDist;
     bool             fAlreadyShrunk;
-    ComponentManager fComponentManager;    
+    ComponentManager fComponentManager;
+    
+    bool fDebugMode;
 };
 #endif


### PR DESCRIPTION
Sometimes during setting up an analysis with OXO, one needs to look at the low-level information being calculated during the evaluation of the Binned negative log-likelihood, `BinnedNLLH::Evaluate()`.

This PR simply adds a debug mode boolean, `fDebugMode`, to the `BinnedNLLH` class. This gets considered within the `Evaluate()` method, where many lines of information are printed to `std::cout` relating to how `nLogLH` is calculated.

By default, debug mode is off, so won't change the functionality of existing code.

There could be a tiny performance hit to code, given that `if (fDebugMode)` gets repeatedly checked. Hopefully this is fairly minimal, as it is merely checking the status of a boolean member.