### PR TITLE
Beeston-Barlow in binned LLH

### DIFF
--- a/examples/beestonBarlowLHH.cpp
+++ b/examples/beestonBarlowLHH.cpp
@@ -1,0 +1,92 @@
+// A very simple llh calculation for testing Barlow-Beeston
+// Based on the example fit code
+//
+// Idea is you can hardcode bin contents of pdf and data
+// and calculate LLHs with/without BB for comparison and
+// validations.
+// The BinnedNLLH will calculate the statistical uncertainty
+// from the generated number of events for the PDF. Here we
+// imagine we've simulated 1000 events, and scaled them down
+// to produce the PDF
+#include <BinnedED.h>
+#include <ROOTNtuple.h>
+#include <BinnedNLLH.h>
+#include <ParameterDict.h>
+
+const std::string bgMCfile    = "";
+const std::string sigMCfile   = "";
+const std::string bgTreeName  = "";
+const std::string sigTreeName = "";
+
+const std::string dataFile = "";
+const std::string dataTreeName = "";
+
+int main(){
+  ////////////////////
+  // 1. Set Up PDFs //
+  ////////////////////
+
+  // Set up binning
+  AxisCollection axes;
+  axes.AddAxis(BinAxis("energy", 0, 4, 4, "Energy"));
+
+  // Only interested in first bit of data ntuple
+  std::vector<std::string> dataObs;
+  dataObs.push_back("energy");
+
+  // Set up pdf with these bins in this observable
+  BinnedED bgPdf("bgPDF",axes);
+  bgPdf.SetObservables(dataObs);
+
+  //Hard code bin contents of PDF
+  bgPdf.SetBinContent(0,20);
+  bgPdf.SetBinContent(1,35);
+  bgPdf.SetBinContent(2,30);
+  bgPdf.SetBinContent(3,15);
+  bgPdf.Normalise();
+
+  //Hard code generated number of events
+  std::vector<int> genRates;
+  genRates.push_back(1000);
+
+  std::cout << "Initialised PDF" << std::endl;
+
+  /////////////////////////////////////
+  // 2. Fill with data and normalise //
+  /////////////////////////////////////
+
+  BinnedED bgData("bgData",axes);
+  bgData.SetObservables(dataObs);
+
+  //Hard code bin contents of data
+  bgData.SetBinContent(0,25);
+  bgData.SetBinContent(1,30);
+  bgData.SetBinContent(2,40);
+  bgData.SetBinContent(3,10);
+
+  std::cout << "Filled data " << std::endl;
+
+  ////////////////////////////
+  // 3. Set Up LH function  //
+  ////////////////////////////
+  BinnedNLLH lhFunction;
+  lhFunction.SetDataDist(bgData); // initialise with the data set
+  lhFunction.AddPdf(bgPdf);        
+  lhFunction.SetGenRates(genRates);
+  lhFunction.SetBarlowBeeston(true);
+
+  lhFunction.RegisterFitComponents();
+
+  std::cout << "Built LH function " << std::endl;
+
+  ParameterDict parameterValues;
+
+  //Set normalisation of PDF
+  parameterValues["bgPDF"] = 100;
+
+  //Calculate and print likelihood
+  lhFunction.SetParameters(parameterValues);
+  std::cout << "Total LogL = " << lhFunction.Evaluate() << std::endl;
+
+  return 0;
+}

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -35,10 +35,6 @@ BinnedNLLH::Evaluate(){
     // loop over bins and calculate the likelihood
     double nLogLH = 0;
 
-    double betaPen    = 0;
-    double sumLogProb = 0;
-    double sumNorm    = 0;
-
     for(size_t i = 0; i < fDataDist.GetNBins(); i++){
 
         double prob = fPdfManager.BinProbability(i);
@@ -81,9 +77,6 @@ BinnedNLLH::Evaluate(){
 	  penalty = (beta-1)*(beta-1)/(2*sigma2);
 	}
 
-	betaPen += penalty;
-	sumLogProb -= fDataDist.GetBinContent(i) *  log(newProb);
-	sumNorm += newProb;
 	// LogL = mu_i - data * log(update MC) + Beta Penalty + Norm Correction
 	nLogLH = nLogLH - fDataDist.GetBinContent(i) *  log(newProb) + penalty + newProb;
 

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -63,7 +63,7 @@ BinnedNLLH::Evaluate(){
 
 	  double sigma2 = 0;
 	  for (unsigned int j=0; j<normalisations.size(); j++)
-	    sigma2 += ( normalisations.at(j) ) / ( (float)fGenRates.at(j) * prob * prob);
+	    sigma2 += ( normalisations.at(j) ) / ( (double)fGenRates.at(j) * prob * prob);
 
 	  //Eqn 11 in https://arxiv.org/abs/1103.0354 for Beta: beta^2 + (mu x sigma^2 - 1)beta - n x sigma^2   (prob is mu, the mc events in bin. n is data events in bin)
 
@@ -71,9 +71,19 @@ BinnedNLLH::Evaluate(){
 	  double b = prob*sigma2 - 1;
 	  //b^2-4ac in quadratic
 	  double det = b*b + 4*fDataDist.GetBinContent(i)*sigma2;
-	  //positive beta
-	  double beta = (-b + sqrt(det))/2;
 
+	  if(det<0.) {    // imaginary roots
+	    throw OXSXException(Formatter()<<"BinnedNLLH:: Negative determinant in beta calculation for Barlow-Beeston. Something has gone terribly wrong.");
+	  }
+
+	  double sign = (b >= 0) ? 1. : -1.;
+	  double q = -0.5*( b + sign*sqrt(det) );
+
+	  double x1 = q;
+	  double x2 = fDataDist.GetBinContent(i)*sigma2/q;
+
+	  double beta = (x1 > x2) ? x1 : x2;
+ 
 	  //and update mc bin content
 	  newProb = beta*prob;
 	  //get beta penalty term

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -139,7 +139,9 @@ BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs,
 }
 
 void
-BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<int>& genrates_, const std::vector<NormFittingStatus>* norm_fitting_statuses){
+BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs,
+		    const std::vector<int>& genrates_,
+		    const std::vector<NormFittingStatus>* norm_fitting_statuses){
 
     if(norm_fitting_statuses != nullptr && pdfs.size() != norm_fitting_statuses->size()) {
         throw DimensionError("BinnedNLLH: number of norm_fittable bools doesn't the number of pdfs");
@@ -154,7 +156,8 @@ BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<int>& g
 }
 
 void
-BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<NormFittingStatus>* norm_fitting_statuses){
+BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs,
+		    const std::vector<NormFittingStatus>* norm_fitting_statuses){
   if(fUseBarlowBeeston)
       throw OXSXException(Formatter()<<"BinnedNLLH:: Must set generated rates if using Barlow-Beeston");
   if(norm_fitting_statuses != nullptr && pdfs.size() != norm_fitting_statuses->size()) {
@@ -170,7 +173,10 @@ BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<NormFit
 }
 
 void
-BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& sys_, const std::vector<int>& genrates_, const std::vector<NormFittingStatus>* norm_fitting_statuses){
+BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs,
+		    const std::vector<std::vector<std::string> >& sys_,
+		    const std::vector<int>& genrates_,
+		    const std::vector<NormFittingStatus>* norm_fitting_statuses){
   if (pdfs.size() != sys_.size())
     throw DimensionError(Formatter()<<"BinnedNLLH:: #sys_ != #group_");
   for(size_t i = 0; i < pdfs.size(); i++){
@@ -183,7 +189,9 @@ BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::ve
 }
 
 void
-BinnedNLLH::AddPdf(const BinnedED& pdf_, const std::vector<std::string>& syss_, const NormFittingStatus norm_fitting_status){
+BinnedNLLH::AddPdf(const BinnedED& pdf_,
+		   const std::vector<std::string>& syss_,
+		   const NormFittingStatus norm_fitting_status){
   if(fUseBarlowBeeston)
     throw OXSXException(Formatter()<<"BinnedNLLH:: Must set generated rates if using Barlow-Beeston");
   fPdfManager.AddPdf(pdf_, norm_fitting_status);
@@ -191,14 +199,17 @@ BinnedNLLH::AddPdf(const BinnedED& pdf_, const std::vector<std::string>& syss_, 
 }
 
 void
-BinnedNLLH::AddPdf(const BinnedED& pdf_, const int& genrate_, const NormFittingStatus norm_fitting_status){
+BinnedNLLH::AddPdf(const BinnedED& pdf_,
+		   const int& genrate_,
+		   const NormFittingStatus norm_fitting_status){
   fPdfManager.AddPdf(pdf_, norm_fitting_status);
   fSystematicManager.AddDist(pdf_,"");
   fGenRates.push_back(genrate_);
 }
 
 void
-BinnedNLLH::AddPdf(const BinnedED& pdf_, const NormFittingStatus norm_fitting_status){
+BinnedNLLH::AddPdf(const BinnedED& pdf_,
+		   const NormFittingStatus norm_fitting_status){
   if(fUseBarlowBeeston)
     throw OXSXException(Formatter()<<"BinnedNLLH:: Must set generated rates if using Barlow-Beeston");
   fPdfManager.AddPdf(pdf_, norm_fitting_status);
@@ -206,8 +217,11 @@ BinnedNLLH::AddPdf(const BinnedED& pdf_, const NormFittingStatus norm_fitting_st
 }
 
 void
-BinnedNLLH::AddPdf(const BinnedED& pdf_, const std::vector<std::string>& syss_, const int& genrate_){
-  fPdfManager.AddPdf(pdf_);
+BinnedNLLH::AddPdf(const BinnedED& pdf_,
+		   const std::vector<std::string>& syss_,
+		   const int& genrate_,
+		   const NormFittingStatus norm_fitting_status){
+  fPdfManager.AddPdf(pdf_, norm_fitting_status);
   fSystematicManager.AddDist(pdf_,syss_);
   fGenRates.push_back(genrate_);
 }

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -116,28 +116,62 @@ BinnedNLLH::BinData(){
 
 void
 BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& sys_){
+
+    if(fUseBarlowBeeston)
+      throw OXSXException(Formatter()<<"BinnedNLLH:: Must set generated rates if using Barlow-Beeston");
     if (pdfs.size() != sys_.size())
        throw DimensionError(Formatter()<<"BinnedNLLH:: #sys_ != #group_");
     for (size_t i = 0; i < pdfs.size(); ++i) { AddPdf( pdfs.at(i), sys_.at(i) ); }
 }
 
 void
+BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<int>& genrates_){
+  for (size_t i = 0; i < pdfs.size(); ++i) { AddPdf(pdfs.at(i), genrates_.at(i)); }
+}
+
+void
 BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs){
+  if(fUseBarlowBeeston)
+    throw OXSXException(Formatter()<<"BinnedNLLH:: Must set generated rates if using Barlow-Beeston");
     for (const auto& pdf: pdfs) { AddPdf(pdf); }
 }
 
 void
+BinnedNLLH::AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& sys_, const std::vector<int>& genrates_){
+  if (pdfs.size() != sys_.size())
+    throw DimensionError(Formatter()<<"BinnedNLLH:: #sys_ != #group_");
+  for (size_t i = 0; i < pdfs.size(); ++i) { AddPdf( pdfs.at(i), sys_.at(i), genrates_.at(i) ); }
+}
+
+void
 BinnedNLLH::AddPdf(const BinnedED& pdf_, const std::vector<std::string>& syss_){
-    fPdfManager.AddPdf(pdf_);
-    fSystematicManager.AddDist(pdf_,syss_);
+  if(fUseBarlowBeeston)
+    throw OXSXException(Formatter()<<"BinnedNLLH:: Must set generated rates if using Barlow-Beeston");
+  fPdfManager.AddPdf(pdf_);
+  fSystematicManager.AddDist(pdf_,syss_);
+}
+
+void
+BinnedNLLH::AddPdf(const BinnedED& pdf_, const int& genrate_){
+  fPdfManager.AddPdf(pdf_);
+  fSystematicManager.AddDist(pdf_,"");
+  fGenRates.push_back(genrate_);
 }
 
 void
 BinnedNLLH::AddPdf(const BinnedED& pdf_){
-    fPdfManager.AddPdf(pdf_);
-    fSystematicManager.AddDist(pdf_,"");
+  if(fUseBarlowBeeston)
+    throw OXSXException(Formatter()<<"BinnedNLLH:: Must set generated rates if using Barlow-Beeston");
+  fPdfManager.AddPdf(pdf_);
+  fSystematicManager.AddDist(pdf_,"");
 }
 
+void
+BinnedNLLH::AddPdf(const BinnedED& pdf_, const std::vector<std::string>& syss_, const int& genrate_){
+  fPdfManager.AddPdf(pdf_);
+  fSystematicManager.AddDist(pdf_,syss_);
+  fGenRates.push_back(genrate_);
+}
 
 void
 BinnedNLLH::SetPdfManager(const BinnedEDManager& man_){
@@ -179,11 +213,6 @@ BinnedNLLH::SetDataDist(const BinnedED& binnedPdf_){
 BinnedED
 BinnedNLLH::GetDataDist() const{
     return fDataDist;
-}
-
-void
-BinnedNLLH::SetGenRates(const std::vector<int>& nGen_){
-  fGenRates = nGen_;
 }
 
 void

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -94,7 +94,7 @@ class BinnedNLLH : public TestStatistic{
     bool             fAlreadyShrunk;
     ComponentManager fComponentManager;
 
-    std::vector<int> fGenRates;
+    std::vector<unsigned int> fGenRates;
     bool fUseBarlowBeeston = false;
     
     bool fDebugMode;

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -20,7 +20,6 @@ class BinnedNLLH : public TestStatistic{
     void   SetPdfManager(const BinnedEDManager&);
     void   SetSystematicManager(const SystematicManager&);
 
-    void   AddPdf(const BinnedED&, const NormFittingStatus norm_fitting_status=DIRECT);
     void   AddSystematic(Systematic* sys_);
     void   AddSystematic(Systematic* sys_, const std::string& group_ );
 
@@ -46,6 +45,8 @@ class BinnedNLLH : public TestStatistic{
     void SetBuffer(const std::string& dim_, unsigned lower_, unsigned upper_);
     std::pair<unsigned, unsigned> GetBuffer(const std::string& dim_) const;
 
+
+    void AddPdf(const BinnedED& pdf, const NormFittingStatus norm_fitting_status=DIRECT);
     void AddPdf(const BinnedED& pdf, const std::vector<std::string>& syss_, const NormFittingStatus norm_fitting_status=DIRECT);
     void AddPdf(const BinnedED& pdf, const int& rate_, const NormFittingStatus norm_fitting_status=DIRECT);
     void AddPdf(const BinnedED& pdf, const std::vector<std::string>& syss_, const int& rate_, const NormFittingStatus norm_fitting_status=DIRECT);
@@ -94,7 +95,7 @@ class BinnedNLLH : public TestStatistic{
     ComponentManager fComponentManager;
 
     std::vector<int> fGenRates;
-    bool fUseBarlowBeeston;    
+    bool fUseBarlowBeeston = false;
     
     bool fDebugMode;
 };

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -38,7 +38,6 @@ class BinnedNLLH : public TestStatistic{
     void SetDataDist(const BinnedED&);
     BinnedED GetDataDist() const;
 
-    void SetGenRates(const std::vector<int>&);
     void SetBarlowBeeston(const bool);
 
     void SetDataSet(DataSet*);
@@ -48,8 +47,12 @@ class BinnedNLLH : public TestStatistic{
     std::pair<unsigned, unsigned> GetBuffer(const std::string& dim_) const;
 
     void AddPdf(const BinnedED& pdf, const std::vector<std::string>& syss_);
+    void AddPdf(const BinnedED& pdf, const int& rate_);
+    void AddPdf(const BinnedED& pdf, const std::vector<std::string>& syss_, const int& rate_);
     void AddPdfs(const std::vector<BinnedED>& pdfs);
     void AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& syss_);
+    void AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<int>& rates_);
+    void AddPdfs(const std::vector<BinnedED>& pdfs, const std::vector<std::vector<std::string> >& syss_, const std::vector<int>& rates_);
 
     void SetBufferAsOverflow(bool b_); // true by default
     bool GetBufferAsOverflow() const;

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -38,6 +38,9 @@ class BinnedNLLH : public TestStatistic{
     void SetDataDist(const BinnedED&);
     BinnedED GetDataDist() const;
 
+    void SetGenRates(const std::vector<int>&);
+    void SetBarlowBeeston(const bool);
+
     void SetDataSet(DataSet*);
     DataSet* GetDataSet();
 
@@ -82,6 +85,8 @@ class BinnedNLLH : public TestStatistic{
     BinnedED         fDataDist;
     bool             fCalculatedDataDist;
     bool             fAlreadyShrunk;
-    ComponentManager fComponentManager;    
+    ComponentManager fComponentManager;
+    std::vector<int> fGenRates;
+    bool fUseBarlowBeeston;    
 };
 #endif

--- a/test/unit/BinnedNLLHTest.cpp
+++ b/test/unit/BinnedNLLHTest.cpp
@@ -94,11 +94,17 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         lh.SetParameters(params);
         REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + constraint));
     }
-    SECTION("Correct Probability with Barlow Beeston"){
-      std::vector<int> genRates(3, pow(10,6));
-      lh.SetGenRates(genRates);
-      lh.SetBarlowBeeston(true);
 
+    std::vector<int> genRates(3, pow(10,6));
+    BinnedNLLH lh2;
+    lh2.SetBarlowBeeston(true);
+    lh2.AddPdf(pdf1, genRates.at(0));
+    lh2.AddPdf(pdf2, genRates.at(1));
+    lh2.AddPdf(pdf3, genRates.at(2));
+    lh2.SetDataSet(&data);
+    lh2.RegisterFitComponents();
+
+    SECTION("Correct Probability with Barlow Beeston"){
       double betaPen    = 0;
       double sumLogProb = 0;
       double sumNorm    = 0;
@@ -129,15 +135,12 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["a"] = 1;
       params["b"] = 1;
       params["c"] = 1;
-      lh.SetParameters(params);
-      REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + betaPen));
+      lh2.SetParameters(params);
+      REQUIRE(lh2.Evaluate() == Approx(sumNorm + sumLogProb + betaPen));
     }
     SECTION("Correct Probability with Barlow Beeston and constraint"){
-      lh.SetConstraint("a", 3, 1);
-      std::vector<int> genRates(3, pow(10,6));
-      lh.SetGenRates(genRates);
-      lh.SetBarlowBeeston(true);
-
+      lh2.SetConstraint("a", 3, 1);
+    
       double betaPen    = 0;
       double sumLogProb = 0;
       double sumNorm    = 0;
@@ -169,14 +172,11 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["a"] = 1;
       params["b"] = 1;
       params["c"] = 1;
-      lh.SetParameters(params);
-      REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + betaPen + constraint));
+      lh2.SetParameters(params);
+      REQUIRE(lh2.Evaluate() == Approx(sumNorm + sumLogProb + betaPen + constraint));
     }
     SECTION("Correct probability with Barlow Beeston and asymmetric constraint"){
-      lh.SetConstraint("b", 5, 1, 2);
-      std::vector<int> genRates(3, pow(10,6));
-      lh.SetGenRates(genRates);
-      lh.SetBarlowBeeston(true);
+      lh2.SetConstraint("b", 5, 1, 2);
 
       double betaPen    = 0;
       double sumLogProb = 0;
@@ -209,14 +209,11 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["a"] = 1;
       params["b"] = 1;
       params["c"] = 1;
-      lh.SetParameters(params);
-      REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + betaPen + constraint));
+      lh2.SetParameters(params);
+      REQUIRE(lh2.Evaluate() == Approx(sumNorm + sumLogProb + betaPen + constraint));
     }
     SECTION("Correct Probability with Barlow Beeston and constraint 2"){
-      lh.SetConstraint("b", -3, 1, 2);
-      std::vector<int> genRates(3, pow(10,6));
-      lh.SetGenRates(genRates);
-      lh.SetBarlowBeeston(true);
+      lh2.SetConstraint("b", -3, 1, 2);
 
       double betaPen    = 0;
       double sumLogProb = 0;
@@ -249,7 +246,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["a"] = 1;
       params["b"] = 1;
       params["c"] = 1;
-      lh.SetParameters(params);
-      REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + betaPen + constraint));
+      lh2.SetParameters(params);
+      REQUIRE(lh2.Evaluate() == Approx(sumNorm + sumLogProb + betaPen + constraint));
     }
 }


### PR DESCRIPTION
The main modification here is incorporating the Barlow-Beeston method for handling the MC statistical uncertainty in the BinnedNLLH test statistic. The user can set a bool when constructing the teststat (defaults off i.e not using Beeston-Barlow) and then can supply a vector of ints, the number of MC events generated for each PDF. [In typing this, I realise this could be handled better by doing this within Add PDF, to at least have a check that number of PDFs == the number of rates supplied. And should also check rates have been supplied if the flag is true.].

In the loop over bins, the beta value is calculated from the uncertainties. This scales the bin probability, and we calculate an extra penalty term to contribute to the likelihood. There's more details on the actual method in the comments, and [DocDB 7360](https://www.snolab.ca/snoplus/private/DocDB/0073/007360/001/MCStatsUncertainty_220401.pdf)

The one small change to the actual BinnedNLLH evaluation without using Beeston-Barlow, is for how we include the number of MC events in each bin.  L = Sum_bins [mu-nlog(mu)] + Sum_constraints[X] where mu is number of MC events in a bin (total from all pdfs), n is data events in the bin, and X is the penalty for a given constraint. Previously, instead of adding mu for each bin, after the bin loop we would just add all the PDF normalisations to the likelihood. The PDFs all have integral 1, so the new normalisation should be the same as adding each bin contents. 
For Barlow-Beeston, instead of mu, we want to include beta x mu in the likelihood. As there is a different beta for each bin, we need to add this to the likelihood in the bin loop, rather than adding the full normalisations after. 

That's all fine, except it brings in to focus what @dcookman and I have been discussing regards normalisations after events are shifted in/out of the ROI. For example, in the BinnedNLLH unit test we have three Gaussians, all with fairly large standard deviations, guaranteeing tails long enough so we have some events in each bin. Beforehand, in the source code, we just add the normalisation (1.0 for each), and in the test, we assert the likelihood should have 3 added to it, for these are normalised Gaussians so of course their normalisations should each be 1. But this is wrong! The Gaussians are wide enough that a fraction of events are outside the range of the PDF. So when we loop over bins in this PR, the total "mu"s added to the likelihood sum to < 3.

In the short term, to overcome this, I've brought down the widths of those Gaussians in the unit tests, so now a negligible fraction of events are outside the PDF range. That's very much sweeping under the carpet for now, but we'll deal with the root issue in another PR. For the Barlow-Beeston tests, I have to loop over bins to do the calculation anyway so it makes no difference.

There's also an example script I've added which is just a tidied up version of what I'd used for some testing, which itself was a modified version of a different example script. The examples are a bit miscellaneous, and I don't think adding this does any harm, but happy to remove it if we think it's not really coherent with other examples.

I've got a couple of improvements to make to the user-interface with Barlow-Beeston, but putting the PR in now so @dcookman you can take a look while I'm away if you get the chance. 

- [x] Move SetGenRates to be done inside a new: AddPdf(const BinnedED& pdf_, const std::vector<int>& nGen_)
- [x] Throw an error if use Barlow-Beeston, but don't set generated rates