### PR TITLE
Refactor Shift for efficiency

### DIFF
--- a/src/systematic/Shift.cpp
+++ b/src/systematic/Shift.cpp
@@ -9,65 +9,45 @@ Shift::Construct(){
     
     if(fTransObs.GetNObservables() != 1)
         throw RepresentationError("Shift systematic must have a 1D representation!");
-
-    const AxisCollection& axes       = fAxes;
-    // the axis to shift
-    const std::string&  shiftAxisName = fTransObs.GetNames().at(0);
-    const BinAxis& shiftAxis          = axes.GetAxis(fDistObs.GetIndex(shiftAxisName));
-
-    const size_t nBins               = axes.GetNBins(); 
-    const size_t shiftAxisNBins      = shiftAxis.GetNBins(); 
- 
-    for(size_t i = 0; i < nBins; i++){
-        // For each old bin, work out the contributions into all of the new bins
-        // indices in other components should be unaffected
-        std::vector<size_t> oldIndices = axes.UnpackIndices(i);
-        size_t shiftBin                = oldIndices.at(fDistObs.GetIndex(shiftAxisName));
-        
-        double shiftedLow   = shiftAxis.GetBinLowEdge(shiftBin)  + fShift;
-        double shiftedHigh  = shiftAxis.GetBinHighEdge(shiftBin) + fShift;
-        double shiftedWidth = shiftedHigh - shiftedLow;
-
-        // new bin to map into, mapping only happens if the indices are the same except the one to 
-        // shift so, loop over the bins in the shift axes and leave other indices the same
-        // the others are zero from initialisation 
-        
-        std::vector<size_t> newIndices = oldIndices;
-        for(size_t j = 0; j < shiftAxisNBins; j++){
-            newIndices[fDistObs.GetIndex(shiftAxisName)] = j;
-            size_t newShiftBin = j;
-                        
-            double newLow  = shiftAxis.GetBinLowEdge(newShiftBin);
-            double newHigh = shiftAxis.GetBinHighEdge(newShiftBin);
-
-            double contribution;
-            // Is it in the shift region at all?
-            if (newLow > shiftedHigh || newHigh < shiftedLow) 
-                contribution = 0;
-
-            else{
-                // Is it fully in the region?
-                bool includedFromBelow = newLow > shiftedLow;
-                bool includedFromAbove = newHigh < shiftedHigh;
-
-                if (includedFromBelow && includedFromAbove) 
-		    // fully inside
-		    contribution = (newHigh - newLow)/shiftedWidth;
-
-                else if (includedFromBelow) 
-                    // spills partly over the top
-                    contribution = (shiftedHigh - newLow)/shiftedWidth;
-
-                else 
-                    // spills partly over the bottom
-                    contribution = (newHigh - shiftedLow)/shiftedWidth;
-            }
-
-            fResponse.SetComponent(axes.FlattenIndices(newIndices), i, contribution);
-        }
-               
+    if (!fAxes.GetNBins()) {
+        throw LogicError("Scale::Construct(): Tried to construct response matrix without an axis collection!");
     }
-    return;
+
+    // If haven't already, generate mapping from full pdf bin IDs
+    //--> transforming subspace bin IDs 
+    if (!fCachedBinMapping) { CacheBinMapping(); }
+
+    // Loop over bins of the scaling axis, and get the user-defined 
+    // shape scale factors at each bin centre.
+    // the axis to scale
+    const std::string&  shiftAxisName = fTransObs.GetNames().at(0);
+    const BinAxis& shiftAxis          = fAxes.GetAxis(fDistObs.GetIndex(shiftAxisName));
+    // Each (pre-scaled) bin gets a mapping from (post-scaled) bins to non-zero values
+    std::vector<std::map<size_t,double>> shift_vals(shiftAxis.GetNBins(), std::map<size_t,double>{});
+    for (size_t bin = 0; bin < shiftAxis.GetNBins(); bin++) {
+        // First - work out edges of scaled bin interval along axis
+        const double shiftLow   = shiftAxis.GetBinLowEdge(bin)  + fShift;
+        const double shiftHigh  = shiftAxis.GetBinHighEdge(bin) + fShift;
+        // Then - which unscaled bins do these edges lie in?
+        const size_t shiftLowIndex = shiftAxis.FindBin(shiftLow);
+        const size_t shiftHighIndex = shiftAxis.FindBin(shiftHigh);
+        // Go through bins in this range, to find contribution to each
+        for (size_t bin_test = shiftLowIndex; bin_test <= shiftHighIndex; bin_test++) {
+            const double contribution = GetBinContribution(shiftAxis, shiftLow, shiftHigh, bin_test);
+            if (contribution > 0) { shift_vals[bin][bin_test] = contribution; }
+        }
+    }
+
+    // Finally, construct the full response matrix by setting the diagonal
+    // elements to their appropriate value, using the bin ID mapping to help.
+    fResponse.SetZeros();
+    for (size_t obs_bin_id = 0; obs_bin_id < fAxes.GetNBins(); obs_bin_id++) {
+        const size_t shiftAxisBin = fDistTransBinMapping.at(obs_bin_id);
+        for (const auto& postShiftBinPair : shift_vals.at(shiftAxisBin)) {
+            const size_t shifted_bin_id = fMappingDistAndTrans.GetComponent(obs_bin_id, postShiftBinPair.first);
+            fResponse.SetComponent(shifted_bin_id, obs_bin_id, postShiftBinPair.second);
+        }
+    }
 }
 
 void
@@ -145,3 +125,83 @@ Shift::SetName(const std::string& name_){
     fName = name_;
 }
 
+
+// PRIVATE METHODS
+
+void Shift::CacheBinMapping() {
+    /*
+    * Because this shape systematic might only require a subset of the
+    * observables to be defined, but still need to act on the whole event
+    * distribution, we need a way of mapping from the full event distribution
+    * to the subspace we actually want to calculate shape values over.
+    */
+    const size_t relativeIndex = fTransObs.GetRelativeIndices(fDistObs).at(0);
+
+    // cache the equivalent index in the binning system of the systematic
+    fDistTransBinMapping.resize(fAxes.GetNBins());
+    for(size_t i = 0; i < fAxes.GetNBins(); i++) {
+        fDistTransBinMapping[i] = fAxes.UnflattenIndex(i, relativeIndex);
+    }
+    /*
+     * Given a bin idx in the full axis collection (1), and another on the
+     * scaling axis (2), this matrix stores the bin idx of the bin with the
+     * same position as (1), excepting for the scaling axis, in which it takes
+     * (2)'s position.
+    */
+    const std::string&  shiftAxisName = fTransObs.GetNames().at(0);
+    const BinAxis& shiftAxis          = fAxes.GetAxis(fDistObs.GetIndex(shiftAxisName));
+
+    fMappingDistAndTrans = DenseMatrix(fAxes.GetNBins(),shiftAxis.GetNBins());
+
+    for (size_t obs_bin_id = 0; obs_bin_id < fAxes.GetNBins(); obs_bin_id++) {
+        const auto obs_bins_unflat = fAxes.UnpackIndices(obs_bin_id);
+
+        for (size_t shift_bin_id = 0; shift_bin_id < shiftAxis.GetNBins(); shift_bin_id++) {
+            auto shifted_bins_unflat = obs_bins_unflat;
+            shifted_bins_unflat[fDistObs.GetIndex(shiftAxisName)] = shift_bin_id;
+            const size_t idx = fAxes.FlattenIndices(shifted_bins_unflat);
+            fMappingDistAndTrans.SetComponent(obs_bin_id, shift_bin_id, idx);
+        }
+    }
+
+    fCachedBinMapping = true;
+}
+
+double Shift::GetBinContribution(const BinAxis& shiftAxis, double shiftedLow,
+                                 double shiftedHigh, size_t bin_test) {
+    /*
+     * Some logic to work out the fraction of the scaled bin interval
+     * within a given test bin interval
+     */
+    const double shiftedWidth = shiftedHigh - shiftedLow;
+    const double testLow  = shiftAxis.GetBinLowEdge(bin_test);
+    const double testHigh = shiftAxis.GetBinHighEdge(bin_test);
+    // Guide:  | | = scaled bin interval, /  / = test bin interval
+    // Is it in the scale region at all?
+    // |   |   /   /        OR    /  /   |  |
+    if (testLow > shiftedHigh || testHigh < shiftedLow) {
+        return 0.;
+    } else{
+        // Is it fully in the region?
+        bool includedFromBelow = testLow > shiftedLow;
+        bool includedFromAbove = testHigh < shiftedHigh;
+
+        if (includedFromBelow) {
+            if (includedFromAbove) {
+                // |  /   /  | : test fully inside scaled bin
+                return (testHigh - testLow)/shiftedWidth;
+            } else {
+                // |  /   |  / : scaled hangs off low end of test only
+                return (shiftedHigh - testLow)/shiftedWidth;
+            }
+        } else {
+            if (includedFromAbove) {
+                // /  |   /  | : scaled hangs off of high end only
+                return (testHigh - shiftedLow)/shiftedWidth;
+            } else {
+                // /  |   |  / : scaled fully within test bin
+                return 1;
+            }
+        }
+    }
+}

--- a/src/systematic/Shift.h
+++ b/src/systematic/Shift.h
@@ -5,10 +5,11 @@
 #define __OXSX_SHIFT__
 #include <Systematic.h>
 #include <string>
+#include <DenseMatrix.h>
 
 class Shift : public Systematic{
  public:
-    Shift(const std::string& name_) : fShift(1), fName(name_), fParamName("shift") {}
+    Shift(const std::string& name_) : fShift(1), fName(name_), fParamName("shift"), fCachedBinMapping(false) {}
     void   SetShift(double);
     double GetShift() const;
     
@@ -32,5 +33,13 @@ class Shift : public Systematic{
     double      fShift;
     std::string fName;
     std::string fParamName;
+
+    std::vector<size_t> fDistTransBinMapping;
+    DenseMatrix fMappingDistAndTrans;
+    bool fCachedBinMapping;
+
+    void CacheBinMapping();
+    double GetBinContribution(const BinAxis& shiftAxis, double shiftedLow,
+                                     double shiftedHigh, size_t bin_test);
 };
 #endif


### PR DESCRIPTION
Following in the footsteps of the efficiency gains made in PR #25 for the `Scale` systematic, the same approach has been applied to the `Shift` systematic.

In order to construct the shift systematic response matrix, we:

1. Cache the bin mapping between elements of the matrix in the full space to the shifting subspace once at the start;
2. Construct the shifting response matrix in the 1D shifting axis only;
3. Use the bin mapping to create the full response matrix.

I have also moved the contents of the calculation of the fractional bin contribution for a given element into its own private method, using the same code as in `Scale` - so the bug fix there is included here too.