### PR TITLE
Add ROOTTree Class

### DIFF
--- a/src/data/ROOTTree.cpp
+++ b/src/data/ROOTTree.cpp
@@ -1,0 +1,103 @@
+#include <ROOTTree.h>
+#include <Event.h>
+#include <iostream>
+#include <Exceptions.h>
+#include <TTree.h>
+#include <TLeaf.h>
+#include <Formatter.hpp>
+
+ROOTTree::ROOTTree(const std::string& fileName_, const std::string& treeName_){
+    fROOTFile = new TFile(fileName_.c_str());
+
+    if (fROOTFile->IsZombie()){
+        delete fROOTFile;
+        throw IOError("ROOTTree::File Does not Exist! or is Zombie " + fileName_);
+    }
+
+    fTree = dynamic_cast<TTree*>(fROOTFile -> Get(treeName_.c_str()));
+
+    if(!fTree){
+        delete fROOTFile;
+        throw IOError(Formatter()<<"ROOTTree::Tree does not exist, or isn't a TTree! tree : " << treeName_ << ", filename: "<<fileName_);
+    }        
+    GatherObservableNames();
+}
+
+ROOTTree::~ROOTTree(){
+    if (fROOTFile)
+        fROOTFile -> Close();
+    delete fROOTFile;
+}
+
+
+std::vector<std::string>
+ROOTTree::GetObservableNames() const{
+    return fObsNames;
+}
+
+Event 
+ROOTTree::Assemble(size_t iEvent_) const{
+    // First, check we're within the range of possible events
+    if (iEvent_ >= GetNEntries())
+        throw NotFoundError(Formatter() << "Exceeded end of ROOT TTree"
+                            << " \n\t(requested " << iEvent_ 
+                            << " but only have " << GetNEntries() << ")");
+    fROOTFile->cd();
+    // Fill the TLeaves with the info from the ith event in the tree
+    fTree -> GetEntry(iEvent_);
+    // Now, get that info from those leaves!
+    const size_t nObs = GetNObservables();
+    std::vector<double> vals;
+    vals.reserve(nObs);
+    for (const TLeaf* leaf : fLeaves) {
+        vals.push_back(leaf->GetValue());
+    }
+    // package that event's info into an OXO Event object, and return
+    Event evt(vals);
+    evt.SetObservableNames(&fObsNames);
+    return evt;
+}
+
+Event
+ROOTTree::GetEntry(size_t iEvent_) const{
+    return Assemble(iEvent_);
+}
+
+void
+ROOTTree::GatherObservableNames(){
+    unsigned nObs = GetNObservables();
+    fObsNames.clear();
+    fLeaves.clear();
+    fObsNames.reserve(nObs);
+    fLeaves.reserve(nObs);
+    for(unsigned i = 0; i < nObs; i++) {
+        const std::string name = fTree->GetListOfBranches()->At(i)->GetName();
+        fObsNames.push_back(name);
+        fLeaves.push_back(fTree->GetLeaf(name.c_str()));
+    }
+}
+
+void
+ROOTTree::LoadBaskets(){
+  if(!fTree)
+    return;
+  fTree->LoadBaskets();
+}
+
+
+void
+ROOTTree::DropBaskets(){
+  if(!fTree)
+    return;
+  fTree->DropBaskets();
+}
+
+unsigned
+ROOTTree::GetNEntries() const{
+    return fTree->GetEntries();
+}
+
+unsigned
+ROOTTree::GetNObservables() const{
+    return fTree->GetNbranches();
+}

--- a/src/data/ROOTTree.h
+++ b/src/data/ROOTTree.h
@@ -1,0 +1,45 @@
+/****************************************************************************************/
+/* Hands out data from a ROOT TTree into an Event object for each Event.                */
+/* Reads directly to save the copy (though this happens only once anyway)               */
+/* Requires all branches in TTree to be castable to a double.                            */
+/****************************************************************************************/
+
+#ifndef __OXSX_ROOT_TREE__
+#define __OXSX_ROOT_TREE__
+#include <DataSet.h>
+#include <string>
+#include <TFile.h>
+#include <vector>
+
+class Event;
+class TTree;
+class TLeaf;
+class ROOTTree : public DataSet{
+ public:
+    ROOTTree(const std::string& fileName_, const std::string& treeName_);
+    ~ROOTTree();
+
+    Event GetEntry(size_t iEvent_) const;
+    unsigned  GetNEntries() const;
+    unsigned  GetNObservables() const;
+
+    void LoadBaskets();
+    void DropBaskets();
+
+    std::vector<std::string> GetObservableNames() const; // just returns the cache
+
+ private:
+    void GatherObservableNames(); // actually works the names out
+    std::vector<std::string> fObsNames;
+    std::vector<TLeaf*> fLeaves;
+
+    // no copying allowed
+    ROOTTree(const ROOTTree&);
+    ROOTTree operator=(const ROOTTree&);
+
+    TFile*   fROOTFile;
+    TTree* fTree;
+    
+    Event Assemble(size_t iEvent_) const;
+};
+#endif


### PR DESCRIPTION
Currently, in order to read in data into OXO from a ROOT file, the file must contain either a histogram or a `TNtuple` object. However, it is rare to actually use `TNtuple` objects in analyses; most of the time people use `TTrees`.

This PR adds the ability to read in an arbitrary `TTree` from a file on disk using a new `ROOTTree` class, assuming that all branches contain variables that can be castable to a double. So, double, float, and integer data types are all fine, but strings, vectors etc. are not.
The `ROOTTree` class has been directly modelled on the existing `ROOTNtuple` class, which only works on files containing a `TNtuple` object. It inherits from the `DataSet` abstract base class, so other classes can understand it sensibly. In particular, it has a `GetEntry(i)` method which will return an `Event` object associated with data from the ith entry of the `TTree`.

It took a bit of cunning to read out the information from a `TTree` object, when we don't know what the branch names or types are! An old ROOT forum post held the answer, which I post here for future reference: https://root-forum.cern.ch/t/get-ttree-entries-without-knowing-type/8358

To confirm that this new class works, I added a new unit test. This test generates a `TTree` object that contains both double and unsigned integer branches, which is then written to a ROOT file. The `ROOTTree` class then reads in this tree from disk, and confirms that the information matches what was expected.