### PR TITLE
Add a functional scale systematic

### DIFF
--- a/src/systematic/ScaleFunction.cpp
+++ b/src/systematic/ScaleFunction.cpp
@@ -1,0 +1,192 @@
+#include <ScaleFunction.h>
+#include <sstream>
+#include <DoubleParameter.h>
+#include <Exceptions.h>
+#include <ContainerTools.hpp>
+
+void ScaleFunction::SetScaleFunction(const ScaleFunc& scale_func,
+                             const std::vector<std::string>& param_names) {
+    /*
+    * Setter for the scale function object; also the only way to add parameters
+    * into the parameter dict: the FitComponent interface allows one to set 
+    * values or rename params, but not add params.
+    */
+    fScaleFunc = scale_func;
+    // Clear any existing param stuff, then add param names with default values
+    fParamDict.clear();
+    for (auto &&param : param_names) {
+        fParamDict[param] = 0;
+    }
+}
+
+void 
+ScaleFunction::Construct(){
+
+    if(fTransObs.GetNObservables() != 1)
+        throw RepresentationError("ScaleFunction systematic must have a 1D representation!");
+    if ( !fScaleFunc || !fAxes.GetNBins()) {
+        throw LogicError("ScaleFunction::Construct(): Tried to construct response matrix without an axis collection!");
+    }
+    // If haven't already, generate mapping from full pdf bin IDs
+    //--> transforming subspace bin IDs 
+    if (!fCachedBinMapping) { CacheBinMapping(); }
+
+    // Loop over bins of the scaling axis, and get the user-defined 
+    // shape scale factors at each bin centre.
+    // the axis to scale
+    const std::string&  scaleAxisName = fTransObs.GetNames().at(0);
+    const BinAxis& scaleAxis          = fAxes.GetAxis(fDistObs.GetIndex(scaleAxisName));
+    // Each (pre-scaled) bin gets a mapping from (post-scaled) bins to non-zero values
+    std::vector<std::map<size_t,double>> scale_vals(scaleAxis.GetNBins(), std::map<size_t,double>{});
+    for (size_t bin = 0; bin < scaleAxis.GetNBins(); bin++) {
+        // First - work out edges of scaled bin interval along axis
+        const double scaledLow   = fScaleFunc( fParamDict, scaleAxis.GetBinLowEdge(bin) );
+        const double scaledHigh  = fScaleFunc( fParamDict, scaleAxis.GetBinHighEdge(bin) );
+        // Then - which unscaled bins do these edges lie in?
+        const size_t scaledLowIndex = scaleAxis.FindBin(scaledLow);
+        const size_t scaledHighIndex = scaleAxis.FindBin(scaledHigh);
+        // Go through bins in this range, to find contribution to each
+        for (size_t bin_test = scaledLowIndex; bin_test <= scaledHighIndex; bin_test++) {
+            const double contribution = GetBinContribution(scaleAxis, scaledLow, scaledHigh, bin_test);
+            if (contribution > 0) { scale_vals[bin][bin_test] = contribution; }
+        }
+    }
+
+    // Finally, construct the full response matrix by setting the diagonal
+    // elements to their appropriate value, using the bin ID mapping to help.
+    fResponse.SetZeros();
+    for (size_t obs_bin_id = 0; obs_bin_id < fAxes.GetNBins(); obs_bin_id++) {
+        const size_t scaleAxisBin = fDistTransBinMapping.at(obs_bin_id);
+        for (const auto& postScaleBinPair : scale_vals.at(scaleAxisBin)) {
+            const size_t scaled_bin_id = fMappingDistAndTrans.GetComponent(obs_bin_id, postScaleBinPair.first);
+            fResponse.SetComponent(scaled_bin_id, obs_bin_id, postScaleBinPair.second);
+        }
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////
+// Make this object fittable, so the scale func params are adjustable //
+////////////////////////////////////////////////////////////////////////
+
+void
+ScaleFunction::SetParameter(const std::string& name_, double value){
+    if(fParamDict.count(name_) == 0)
+        throw ParameterError("ScaleFunction: can't set " + name_);
+    fParamDict[name_] = value;
+}
+
+double
+ScaleFunction::GetParameter(const std::string& name_) const{
+    if(fParamDict.count(name_) == 0)
+        throw ParameterError("ScaleFunction: parameter " + name_ + "does not exist");
+    return fParamDict.at(name_);
+}
+
+void
+ScaleFunction::SetParameters(const ParameterDict& pd_){
+    for (auto &&pair : pd_) {
+        try{ fParamDict[pair.first] = pair.second; }
+        catch(const std::out_of_range& e_){
+            throw ParameterError("ScaleFunction: cannot set parameter " + pair.first);
+        }
+    }   
+}
+
+std::set<std::string>
+ScaleFunction::GetParameterNames() const {
+    std::set<std::string> set;
+    for (auto &&pair : fParamDict) {
+        set.insert(pair.first);
+    }
+    return set;
+}
+
+void 
+ScaleFunction::RenameParameter(const std::string& old_, const std::string& new_){
+    if(fParamDict.count(old_) == 0)
+        throw ParameterError("ScaleFunction: can't rename " + old_);
+    fParamDict[new_] = fParamDict.at(old_);
+    fParamDict.erase(old_);
+}
+
+// PRIVATE METHODS
+
+void
+ScaleFunction::CacheBinMapping() {
+    /*
+    * Because this shape systematic might only require a subset of the
+    * observables to be defined, but still need to act on the whole event
+    * distribution, we need a way of mapping from the full event distribution
+    * to the subspace we actually want to calculate shape values over.
+    */
+    const size_t relativeIndex = fTransObs.GetRelativeIndices(fDistObs).at(0);
+
+    // cache the equivalent index in the binning system of the systematic
+    fDistTransBinMapping.resize(fAxes.GetNBins());
+    for(size_t i = 0; i < fAxes.GetNBins(); i++) {
+        fDistTransBinMapping[i] = fAxes.UnflattenIndex(i, relativeIndex);
+    }
+    /*
+     * Given a bin idx in the full axis collection (1), and another on the
+     * scaling axis (2), this matrix stores the bin idx of the bin with the
+     * same position as (1), excepting for the scaling axis, in which it takes
+     * (2)'s position.
+    */
+    const std::string&  scaleAxisName = fTransObs.GetNames().at(0);
+    const BinAxis& scaleAxis          = fAxes.GetAxis(fDistObs.GetIndex(scaleAxisName));
+
+    fMappingDistAndTrans = DenseMatrix(fAxes.GetNBins(),scaleAxis.GetNBins());
+
+    for (size_t obs_bin_id = 0; obs_bin_id < fAxes.GetNBins(); obs_bin_id++) {
+        const auto obs_bins_unflat = fAxes.UnpackIndices(obs_bin_id);
+
+        for (size_t scale_bin_id = 0; scale_bin_id < scaleAxis.GetNBins(); scale_bin_id++) {
+            auto scaled_bins_unflat = obs_bins_unflat;
+            scaled_bins_unflat[fDistObs.GetIndex(scaleAxisName)] = scale_bin_id;
+            const size_t idx = fAxes.FlattenIndices(scaled_bins_unflat);
+            fMappingDistAndTrans.SetComponent(obs_bin_id, scale_bin_id, idx);
+        }
+    }
+
+    fCachedBinMapping = true;
+}
+
+double ScaleFunction::GetBinContribution(const BinAxis& scaleAxis, double scaledLow,
+                                 double scaledHigh, size_t bin_test) {
+    /*
+     * Some logic to work out the fraction of the scaled bin interval
+     * within a given test bin interval
+     */
+    const double scaledWidth = scaledHigh - scaledLow;
+    const double testLow  = scaleAxis.GetBinLowEdge(bin_test);
+    const double testHigh = scaleAxis.GetBinHighEdge(bin_test);
+    // Guide:  | | = scaled bin interval, /  / = test bin interval
+    // Is it in the scale region at all?
+    // |   |   /   /        OR    /  /   |  |
+    if (testLow > scaledHigh || testHigh < scaledLow) {
+        return 0.;
+    } else{
+        // Is it fully in the region?
+        bool includedFromBelow = testLow > scaledLow;
+        bool includedFromAbove = testHigh < scaledHigh;
+
+        if (includedFromBelow) {
+            if (includedFromAbove) {
+                // |  /   /  | : test fully inside scaled bin
+                return (testHigh - testLow)/scaledWidth;
+            } else {
+                // |  /   |  / : scaled hangs off low end of test only
+                return (scaledHigh - testLow)/scaledWidth;
+            }
+        } else {
+            if (includedFromAbove) {
+                // /  |   /  | : scaled hangs off of high end only
+                return (testHigh - scaledLow)/scaledWidth;
+            } else {
+                // /  |   |  / : scaled fully within test bin
+                return 1;
+            }
+        }
+    }
+}

--- a/src/systematic/ScaleFunction.h
+++ b/src/systematic/ScaleFunction.h
@@ -1,0 +1,55 @@
+/*****************************************/
+/* A scale function error on an observable */
+/*****************************************/
+#ifndef __OXSX_SCALEFUNCTION__
+#define __OXSX_SCALEFUNCTION__
+#include <Systematic.h>
+#include <string>
+#include <DenseMatrix.h>
+#include <functional>
+
+/*
+* Firstly, create a typdef for a general function that just 
+* takes in a double and the parameter dict, and returns a
+* double.
+*/
+typedef std::function<double(const ParameterDict&,
+                           const double&)> ScaleFunc;
+
+class ScaleFunction : public Systematic{
+ public:
+    ScaleFunction(const std::string& name_) : fScaleFunc(), fParamDict(), fName(name_), fCachedBinMapping(false) {}
+
+    void SetScaleFunction(const ScaleFunc& scale_func,
+                          const std::vector<std::string>& param_names);
+
+    void Construct();
+
+    void   SetParameter(const std::string& name_, double value);
+    double GetParameter(const std::string& name_) const;
+
+    void   SetParameters(const ParameterDict&);
+    ParameterDict GetParameters() const { return fParamDict; }
+    size_t GetParameterCount() const { return fParamDict.size(); }
+
+    std::set<std::string> GetParameterNames() const;
+    void   RenameParameter(const std::string& old_, const std::string& new_);
+
+    std::string GetName() const { return fName; }
+    void SetName(const std::string& name_) { fName = name_; }
+ 
+ private:
+    ScaleFunc          fScaleFunc;
+    ParameterDict      fParamDict;
+    std::string        fName;
+    std::string        fParamName;
+
+    std::vector<size_t> fDistTransBinMapping;
+    DenseMatrix fMappingDistAndTrans;
+    bool fCachedBinMapping;
+
+    void CacheBinMapping();
+    double GetBinContribution(const BinAxis& scaleAxis, double scaledLow,
+                                     double scaledHigh, size_t bin_test);
+};
+#endif

--- a/test/unit/ScaleFuncSystTest.cpp
+++ b/test/unit/ScaleFuncSystTest.cpp
@@ -1,0 +1,132 @@
+#include <catch.hpp>
+#include <SystematicManager.h>
+#include <ScaleFunction.h>
+
+double linear_func(const ParameterDict& params, const double& obs_val) {
+    /*
+    * Simple non-trivial function, linear in x:
+    * returns = a*x + b
+    */
+    return params.at("a") * obs_val + params.at("b");
+}
+
+TEST_CASE("Simple ScaleFunction systematic on 1d PDF"){
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis0", 0, 5, 5));
+    std::vector<std::string> observables;
+    observables.push_back("obs0");
+
+    BinnedED pdf1("pdf1", axes);
+    pdf1.SetBinContent(0, 0);
+    pdf1.SetBinContent(1, 10);
+    pdf1.SetBinContent(2, 0);
+    pdf1.SetBinContent(3, 0);
+    pdf1.SetBinContent(4, 0);
+    pdf1.SetObservables(observables);
+
+    const std::vector<std::string> scale_param_names {"a", "b"};
+    const std::set<std::string> scale_param_names_set {"a", "b"};
+
+    ScaleFunction* scale_func = new ScaleFunction("scale_func_sys");
+    scale_func->SetScaleFunction(linear_func, scale_param_names);
+    const auto params = ParameterDict({{"a", 2}, {"b", 0}});
+    scale_func->SetParameters(params);
+    scale_func->SetAxes(axes);
+    scale_func->SetTransformationObs(observables);
+    scale_func->SetDistributionObs(observables);
+    scale_func->Construct();
+
+    SECTION("Check systematic name") {
+        REQUIRE( scale_func->GetName() == "scale_func_sys" );
+    }
+
+    SECTION("Check observables used") {
+        REQUIRE( scale_func->GetDistributionObs() == observables );
+        REQUIRE( scale_func->GetTransformationObs() == observables );
+    }
+
+    SECTION("Check axes") {
+        REQUIRE( scale_func->GetAxes() == axes );
+    }
+
+    SECTION("Check argument information") {
+        REQUIRE( scale_func->GetParameterCount() == 2 );
+        REQUIRE( scale_func->GetParameterNames() == scale_param_names_set );
+        REQUIRE( scale_func->GetParameter("a") == 2 );
+        REQUIRE( scale_func->GetParameter("b") == 0 );
+        REQUIRE( scale_func->GetParameters() == params );
+    }
+
+    SystematicManager man;
+    Systematic* syst1;
+    syst1 = scale_func;
+    man.Add(syst1);
+    man.AddDist(pdf1,"");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs;
+    pdfs.push_back(pdf1);
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs,pdfs);
+
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals;
+    correctVals.push_back(0);
+    correctVals.push_back(0);
+    correctVals.push_back(5);
+    correctVals.push_back(5);
+    correctVals.push_back(0);
+
+    REQUIRE(modifiedObs == correctVals);
+}
+
+TEST_CASE("Another simple ScaleFunction systematic on 2d PDF"){
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("axis0", 0, 5, 5));
+    axes.AddAxis(BinAxis("axis1", 1, 3, 2));
+    std::vector<std::string> observables;
+    observables.push_back("obs0");
+    observables.push_back("obs1");
+
+    BinnedED pdf1("pdf1", axes);
+    pdf1.SetBinContent(axes.FlattenIndices({0,0}), 12);
+    pdf1.SetBinContent(axes.FlattenIndices({1,1}), 6);
+    pdf1.SetObservables(observables);
+
+    const std::vector<std::string> scale_param_names {"a", "b"};
+    const std::set<std::string> scale_param_names_set {"a", "b"};
+
+    ScaleFunction* scale_func = new ScaleFunction("scale_func_sys");
+    scale_func->SetScaleFunction(linear_func, scale_param_names);
+    const auto params = ParameterDict({{"a", 3}, {"b", 1}});
+    scale_func->SetParameters(params);
+    scale_func->SetAxes(axes);
+    scale_func->SetTransformationObs({"obs0"});
+    scale_func->SetDistributionObs(observables);
+    scale_func->Construct();
+
+    SystematicManager man;
+    Systematic* syst1;
+    syst1 = scale_func;
+    man.Add(syst1);
+    man.AddDist(pdf1,"");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs;
+    pdfs.push_back(pdf1);
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs,pdfs);
+
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals(10,0);
+    correctVals[axes.FlattenIndices({1,0})] = 4;
+    correctVals[axes.FlattenIndices({2,0})] = 4;
+    correctVals[axes.FlattenIndices({3,0})] = 4;
+    correctVals[axes.FlattenIndices({4,1})] = 2;
+    
+    for (size_t i=0; i<modifiedObs.size(); i++) {
+        REQUIRE(modifiedObs.at(i) == Approx(correctVals.at(i)));
+    }
+}


### PR DESCRIPTION
Adding a scaled systematic, but instead of just a linear scale with no offset, the user can input any function to scale bin edges by.

All the bin contribution calculations are taken from the original Scale systematics. The adding of the function is done in the same way as the Shape systematic. If you were to use a function that just returned a*x, where a is a parameter of the function, and x is the observable, the systematic behaves in the same way as the original Scale.

Tomorrow I'll add a Birk's scaling like function to use this in anger with!