### PR TITLE
Name histograms before saving them in root

### DIFF
--- a/src/data/IO.cpp
+++ b/src/data/IO.cpp
@@ -285,25 +285,31 @@ IO::UnpackString(const std::string& str_){
 
 
 void
-IO::SaveHistogram(const Histogram& hist_, const std::string& filename_){
+IO::SaveHistogram(const Histogram& hist_, const std::string& filename_, const std::string& histname_){
     std::string ext = GetExt(filename_);
     if(ext == "h5")
         SaveHistogramH5(hist_, filename_);
 
     else if(ext == "root")
-        SaveHistogramROOT(hist_, filename_);
+        SaveHistogramROOT(hist_, filename_, histname_);
 
     else
         throw IOError("IO::SaveDataSet Don't know how to save file as ." + ext);
 }
 
 void
-IO::SaveHistogramROOT(const Histogram& hist_, const std::string& filename_){
+IO::SaveHistogramROOT(const Histogram& hist_, const std::string& filename_, const std::string& histname_){
     int dim = hist_.GetNDims();
-    if(dim == 1)
-        DistTools::ToTH1D(hist_).SaveAs(filename_.c_str());
-    else if(dim == 2)
-        DistTools::ToTH2D(hist_).SaveAs(filename_.c_str());
+    if(dim == 1){
+        TH1D hist = DistTools::ToTH1D(hist_);
+        hist.SetName(histname_.c_str());
+        hist.SaveAs(filename_.c_str());
+    }
+    else if(dim == 2){
+        TH2D hist = DistTools::ToTH2D(hist_);
+        hist.SetName(histname_.c_str());
+        hist.SaveAs(filename_.c_str());
+    }
     else
         throw IOError(Formatter() << "IO::SaveHistogramROOT don't know how to save a " << dim
                       << "histogram (just 1D or 2D)");

--- a/src/data/IO.h
+++ b/src/data/IO.h
@@ -22,8 +22,8 @@ class IO{
       
 
     static void SaveHistogramH5(const Histogram& , const std::string& filename_);
-    static void SaveHistogramROOT(const Histogram& , const std::string& filename_);
-    static void SaveHistogram(const Histogram&, const std::string& filename_);
+    static void SaveHistogramROOT(const Histogram& , const std::string& filename_, const std::string& = "oxsx_saved");
+    static void SaveHistogram(const Histogram&, const std::string& filename_, const std::string& = "oxsx_saved");
 
     static OXSXDataSet* LoadDataSet(const std::string& filename_);
     static Histogram    LoadHistogram(const std::string& filename_);

--- a/src/dist/DistTools.cpp
+++ b/src/dist/DistTools.cpp
@@ -41,7 +41,8 @@ DistTools::ToTH1D(const BinnedED& pdf_, const bool widthCorrect_){
     std::vector<double> highEdges = axis.GetBinHighEdges();
     lowEdges.push_back(highEdges.back());
 
-    TH1D rtHist("", "", nBins, &lowEdges.at(0));
+    TH1D rtHist(pdf_.GetName().c_str(), pdf_.GetName().c_str(), nBins, &lowEdges.at(0));
+    std::cout << "saving eh " << pdf_.GetName() << std::endl;
     rtHist.SetDirectory(0);
     rtHist.GetXaxis() -> SetTitle(axis.GetLatexName().c_str());
 

--- a/src/dist/DistTools.cpp
+++ b/src/dist/DistTools.cpp
@@ -41,8 +41,7 @@ DistTools::ToTH1D(const BinnedED& pdf_, const bool widthCorrect_){
     std::vector<double> highEdges = axis.GetBinHighEdges();
     lowEdges.push_back(highEdges.back());
 
-    TH1D rtHist(pdf_.GetName().c_str(), pdf_.GetName().c_str(), nBins, &lowEdges.at(0));
-    std::cout << "saving eh " << pdf_.GetName() << std::endl;
+    TH1D rtHist("", "", nBins, &lowEdges.at(0));
     rtHist.SetDirectory(0);
     rtHist.GetXaxis() -> SetTitle(axis.GetLatexName().c_str());
 


### PR DESCRIPTION
At the moment, if you invoke SaveHistogram() with a root file argument, the histogram gets saved without a title/name. So you have to get a bit funky with how you then access that histogram. This PR adds an option to give it a name when saving, in the same way this is already done for SaveDataset().

As for SaveDataset, the name gets passed to SaveHistogramRoot but not SaveHistogramH5, and defaults to "oxsx_saved"


Default behaviour should be the same, so you don't have to add any arguments for calls to SaveHistogram in your code if you don't want to, but just note now those histograms will be named 