### PR TITLE
Fix examples; remove _norm addition from EDManager

### DIFF
--- a/examples/DataSetGeneration.cpp
+++ b/examples/DataSetGeneration.cpp
@@ -3,15 +3,22 @@
 #include <ROOTNtuple.h>
 int main(){        
     // (filename, tree name)        
-    ROOTNtuple zeroNuMC("<filename1>", "treename");        
-    ROOTNtuple twoNuMC( "<filename2>", "treename");        
+    ROOTNtuple zeroNuMC("<filename1>", "treename");
+    ROOTNtuple twoNuMC( "<filename2>", "treename");
     ROOTNtuple b8NuMC(  "<filename3>", "treename");
+
+    std::vector<bool> bootstraps;
     
     // DataSetGenerator        
     DataSetGenerator dataGen;        
-    dataGen.AddDataSet(&zeroNuMC, 5, false);  // second arg is the expected rate        
-    dataGen.AddDataSet(&twoNuMC, 50, false);        
-    dataGen.AddDataSet(&b8NuMC, 100, false);        
+    dataGen.AddDataSet(&zeroNuMC, 5, false);  // second arg is the expected rate
+    bootstraps.push_back(true);
+    dataGen.AddDataSet(&twoNuMC, 50, false);
+    bootstraps.push_back(true);
+    dataGen.AddDataSet(&b8NuMC, 100, false);
+    bootstraps.push_back(true);
+
+    dataGen.SetBootstrap(bootstraps);
     
     // Generate a data set        
     OXSXDataSet fakeData  = dataGen.PoissonFluctuatedDataSet();

--- a/examples/VaryingCDF.cpp
+++ b/examples/VaryingCDF.cpp
@@ -136,8 +136,8 @@ int main()
     AxisCollection axes;
     axes.AddAxis(BinAxis("axis1", 10, 30 ,200));
 
-    ObsSet  obsSet(0);
-    ObsSet  obsSetToTransform(0);
+    ObsSet  obsSet("axis1");
+    ObsSet  obsSetToTransform("axis1");
 
     Convolution* conv_a = new Convolution("conv_a");
     VaryingCDF smear("smear");

--- a/examples/beestonBarlowLHH.cpp
+++ b/examples/beestonBarlowLHH.cpp
@@ -46,8 +46,7 @@ int main(){
   bgPdf.Normalise();
 
   //Hard code generated number of events
-  std::vector<int> genRates;
-  genRates.push_back(1000);
+  const int gen_rate = 1000;
 
   std::cout << "Initialised PDF" << std::endl;
 
@@ -71,8 +70,7 @@ int main(){
   ////////////////////////////
   BinnedNLLH lhFunction;
   lhFunction.SetDataDist(bgData); // initialise with the data set
-  lhFunction.AddPdf(bgPdf);        
-  lhFunction.SetGenRates(genRates);
+  lhFunction.AddPdf(bgPdf, gen_rate);
   lhFunction.SetBarlowBeeston(true);
 
   lhFunction.RegisterFitComponents();

--- a/examples/simpleFit.cpp
+++ b/examples/simpleFit.cpp
@@ -69,19 +69,17 @@ int main(){
     // Set up optimisation parameters.
     // Grid search needs a minimum, maximum and step size for each fit
     // parameter.
-    // For BinnedEDs the normalisations are named by appending "_norm" to the
-    // BinnedED name.
     ParameterDict minima;
-    minima["bgPDF_norm"]= 800;
-    minima["signalPDF_norm"]=800;
+    minima["bgPDF"]= 800;
+    minima["signalPDF"]=800;
 
     ParameterDict maxima;
-    maxima["bgPDF_norm"]= 2200;
-    maxima["signalPDF_norm"]=2200;
+    maxima["bgPDF"]= 2200;
+    maxima["signalPDF"]=2200;
 
     ParameterDict steps;
-    steps["bgPDF_norm"]= 200;
-    steps["signalPDF_norm"]=200;
+    steps["bgPDF"]= 200;
+    steps["signalPDF"]=200;
     
     // Set optimisation parameters.
     gSearch.SetMinima(minima);

--- a/examples/simpleSystematicFit.cpp
+++ b/examples/simpleSystematicFit.cpp
@@ -83,12 +83,12 @@ int main(){
 
     // BinnedED fakeData= dataGen.ExpectedRatesED();
     BinnedED fakeData= dataGen.PoissonFluctuatedED();
-
+    std::cout << "Fake data set up\n";
 
     ///////////////////////
     // 3. The systematic //
     ///////////////////////
-    ObsSet  obsSet(0);
+    ObsSet  obsSet("axis1");
 
     Convolution* conv_a = new Convolution("conv_a");
     Gaussian* gaus_a = new Gaussian(0,1,"gaus_a"); 
@@ -102,31 +102,31 @@ int main(){
     conv_a->SetDistributionObs(obsSet);
     conv_a->Construct();
 
-
+    std::cout << "Convolution constructed\n";
     ////////////////////////////////////
     // 4. Setting optimisation limits //
     ////////////////////////////////////
     ParameterDict minima;
-    minima["a_mc_norm"] = 10; 
+    minima["a_mc"] = 10; 
     minima["gaus_a_1" ] = -15;
     minima["gaus_a_2" ] = 0;  
 
     ParameterDict maxima;
-    maxima["a_mc_norm"] = 200000;
+    maxima["a_mc"] = 200000;
     maxima["gaus_a_1" ] = 15;    
     maxima["gaus_a_2" ] = 1;     
 
     ParameterDict initialval;
-    initialval["a_mc_norm"] = 90000; 
+    initialval["a_mc"] = 90000; 
     initialval["gaus_a_1"]  = 4.;   
     initialval["gaus_a_2"]  = 1.;    
 
     ParameterDict initialerr;
-    initialerr["a_mc_norm"] = 0.1*initialval["a_mc_norm"];
+    initialerr["a_mc"] = 0.1*initialval["a_mc"];
     initialerr["gaus_a_1" ] = 0.1*initialval["gaus_a_1"]; 
     initialerr["gaus_a_2" ] = 0.1*initialval["gaus_a_2"]; 
 
-
+    std::cout << "Limits set\n";
     //////////////////////////////////////////
     // 5. Setting up likelihood, including  //
     //    PDF, fake data and systematic     //
@@ -136,7 +136,7 @@ int main(){
 
     BinnedNLLH lh; 
     lh.SetBufferAsOverflow(false);
-    lh.SetBuffer(0,BuffLow,BuffHigh);
+    lh.SetBuffer("axis1",BuffLow,BuffHigh);
     // Initialise with the data set
     lh.SetDataDist(fakeData); 
     //Add systematics to the global group "", will be applied to all distributions.
@@ -144,7 +144,7 @@ int main(){
     // Associate EDs to lh, systematics will be applied
     lh.AddPdf(mcPdfs.at(0));
 
-
+    std::cout << "BinnedNLLH set up\n";
     ////////////
     // 6. Fit //
     ////////////
@@ -178,7 +178,7 @@ int main(){
 
 
     BiResult = BiSmearer( BiHolder );
-    BiResult.Scale(bestResult.at("a_mc_norm"));
+    BiResult.Scale(bestResult.at("a_mc"));
 
     TH1D fakeDataHist;
     TH1D BiFit;
@@ -230,7 +230,7 @@ int main(){
     leg->Draw(); 
     
     TPaveText pt(0.7,0.2,1.0,0.6,"NDC");
-    pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc_norm"]));
+    pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc"]));
     pt.AddText(Form("a conv mean = %.2f",bestResult["gaus_a_1"]));
     pt.AddText(Form("a conv RMS= %.2f",bestResult["gaus_a_2"]));
     pt.SetFillColor(kWhite);

--- a/examples/systematicFit.cpp
+++ b/examples/systematicFit.cpp
@@ -107,7 +107,7 @@ fitWithSystematicsGroups(){
 
     padPDFs(mcPdfs);
 
-    ObsSet  obsSet(0);
+    ObsSet  obsSet("axis1");
 
     Convolution* conv_a = new Convolution("conv_a");
     Gaussian* gaus_a = new Gaussian(0,1,"gaus_a"); 
@@ -133,42 +133,32 @@ fitWithSystematicsGroups(){
 
     // Setting optimisation limits
     ParameterDict minima;
-    minima["a_mc_norm"] = 10; 
-    minima["b_mc_norm"] = 10; 
+    minima["a_mc"] = 10; 
+    minima["b_mc"] = 10; 
     minima["gaus_a_1" ] = -15;
     minima["gaus_a_2" ] = 0;  
     minima["gaus_b_1" ] = -15;
     minima["gaus_b_2" ] = 0;  
 
     ParameterDict maxima;
-    maxima["a_mc_norm"] = 200000;
-    maxima["b_mc_norm"] = 200000;
+    maxima["a_mc"] = 200000;
+    maxima["b_mc"] = 200000;
     maxima["gaus_a_1" ] = 15;    
     maxima["gaus_a_2" ] = 1;     
     maxima["gaus_b_1" ] = 16.;   
     maxima["gaus_b_2" ] = 1;     
 
-
-    // ParameterDict initialval;
-    // Rand rand;
-    // initialval["a_mc_norm"] = rand.UniformRange(minima["a_mc_norm"],maxima["a_mc_norm"]); 
-    // initialval["b_mc_norm"] = rand.UniformRange(minima["b_mc_norm"],maxima["b_mc_norm"]); 
-    // initialval["gaus_a_1" ] = rand.UniformRange(minima["gaus_a_1" ],maxima["gaus_a_1" ]); 
-    // initialval["gaus_a_2" ] = rand.UniformRange(minima["gaus_a_2" ],maxima["gaus_a_2" ]); 
-    // initialval["gaus_b_1" ] = rand.UniformRange(minima["gaus_b_1" ],maxima["gaus_b_1" ]); 
-    // initialval["gaus_b_2" ] = rand.UniformRange(minima["gaus_b_2" ],maxima["gaus_b_2" ]); 
-
     ParameterDict initialval;
-    initialval["a_mc_norm"] = 90000; 
-    initialval["b_mc_norm"] = 90000; 
+    initialval["a_mc"] = 90000; 
+    initialval["b_mc"] = 90000; 
     initialval["gaus_a_1"]  = -4.;   
     initialval["gaus_a_2"]  = 1.;    
     initialval["gaus_b_1"]  = 9.;    
     initialval["gaus_b_2"]  = 1.;    
 
     ParameterDict initialerr;
-    initialerr["a_mc_norm"] = 0.1*initialval["a_mc_norm"];
-    initialerr["b_mc_norm"] = 0.1*initialval["b_mc_norm"];
+    initialerr["a_mc"] = 0.1*initialval["a_mc"];
+    initialerr["b_mc"] = 0.1*initialval["b_mc"];
     initialerr["gaus_a_1" ] = 0.1*initialval["gaus_a_1"]; 
     initialerr["gaus_a_2" ] = 0.1*initialval["gaus_a_2"]; 
     initialerr["gaus_b_1" ] = 0.1*initialval["gaus_b_1"]; 
@@ -180,7 +170,7 @@ fitWithSystematicsGroups(){
 
     BinnedNLLH lh; 
     lh.SetBufferAsOverflow(false);
-    lh.SetBuffer(0,BuffLow,BuffHigh);
+    lh.SetBuffer("axis1",BuffLow,BuffHigh);
     lh.SetDataDist(fakeData); // initialise with the data set
     
     // Add systematics to groups. The order in which the systematic is added to
@@ -231,8 +221,8 @@ fitWithSystematicsGroups(){
         PoResult = PoSmearer( PoHolder );
         BiResult = BiSmearer( BiHolder );
 
-        BiResult.Scale(bestResult.at("a_mc_norm"));
-        PoResult.Scale(bestResult.at("b_mc_norm"));
+        BiResult.Scale(bestResult.at("a_mc"));
+        PoResult.Scale(bestResult.at("b_mc"));
 
         TH1D fakeDataHist;
         TH1D BiFit;
@@ -296,8 +286,8 @@ fitWithSystematicsGroups(){
         leg->Draw(); 
 
         TPaveText pt(0.7,0.2,1.0,0.6,"NDC");
-        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc_norm"]));
-        pt.AddText(Form("b norm = %.2f",bestResult["b_mc_norm"]));
+        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc"]));
+        pt.AddText(Form("b norm = %.2f",bestResult["b_mc"]));
         pt.AddText(Form("a conv mean = %.2f",bestResult["gaus_a_1"]));
         pt.AddText(Form("a conv RMS= %.2f",bestResult["gaus_a_2"]));
         pt.AddText(Form("b conv mean = %.2f",bestResult["gaus_b_1"]));
@@ -342,7 +332,7 @@ fitWithGlobalSystematics(){
     Rand::SetSeed(0);
     AxisCollection axes;
     axes.AddAxis(BinAxis("axis1", 0, 50 ,200));
-    ObsSet  obsSet(0);
+    ObsSet  obsSet("axis1");
 
     // Setting up artificial scale with a scaleFactor = 1.5.
     Scale* scale = new Scale("scale");
@@ -392,32 +382,23 @@ fitWithGlobalSystematics(){
 
     // Setting optimisation limits
     ParameterDict minima;
-    minima["a_mc_norm"] = 10; 
-    minima["b_mc_norm"] = 10; 
+    minima["a_mc"] = 10; 
+    minima["b_mc"] = 10; 
     minima["scaleFactor" ] = 0.1;
 
     ParameterDict maxima;
-    maxima["a_mc_norm"] = 200000;
-    maxima["b_mc_norm"] = 200000;
-    maxima["scaleFactor" ] = 2.0;    
-
-    // ParameterDict initialval;
-    // Rand rand;
-    // initialval["a_mc_norm"] = rand.UniformRange(minima["a_mc_norm"],maxima["a_mc_norm"]); 
-    // initialval["b_mc_norm"] = rand.UniformRange(minima["b_mc_norm"],maxima["b_mc_norm"]); 
-    // initialval["gaus_a_1" ] = rand.UniformRange(minima["gaus_a_1" ],maxima["gaus_a_1" ]); 
-    // initialval["gaus_a_2" ] = rand.UniformRange(minima["gaus_a_2" ],maxima["gaus_a_2" ]); 
-    // initialval["gaus_b_1" ] = rand.UniformRange(minima["gaus_b_1" ],maxima["gaus_b_1" ]); 
-    // initialval["gaus_b_2" ] = rand.UniformRange(minima["gaus_b_2" ],maxima["gaus_b_2" ]); 
+    maxima["a_mc"] = 200000;
+    maxima["b_mc"] = 200000;
+    maxima["scaleFactor" ] = 2.0;
 
     ParameterDict initialval;
-    initialval["a_mc_norm"] = 90000; 
-    initialval["b_mc_norm"] = 90000; 
+    initialval["a_mc"] = 90000; 
+    initialval["b_mc"] = 90000; 
     initialval["scaleFactor"]  = 1;   
 
     ParameterDict initialerr;
-    initialerr["a_mc_norm"] = 0.1*initialval["a_mc_norm"];
-    initialerr["b_mc_norm"] = 0.1*initialval["b_mc_norm"];
+    initialerr["a_mc"] = 0.1*initialval["a_mc"];
+    initialerr["b_mc"] = 0.1*initialval["b_mc"];
     initialerr["scaleFactor" ] = 0.1*initialval["scaleFactor"]; 
 
     //Setting up likelihood.
@@ -426,7 +407,7 @@ fitWithGlobalSystematics(){
 
     BinnedNLLH lh; 
     lh.SetBufferAsOverflow(false);
-    lh.SetBuffer(0,BuffLow,BuffHigh);
+    lh.SetBuffer("axis1",BuffLow,BuffHigh);
     lh.SetDataDist(fakeData); // initialise with the data set
 
     // Add global systematic. Order in which global systematics are applied is the same as the order in which they are applied.
@@ -467,8 +448,8 @@ fitWithGlobalSystematics(){
         PoResult = scale->operator()( PoHolder );
         BiResult = scale->operator()( BiHolder );
 
-        BiResult.Scale(bestResult.at("a_mc_norm"));
-        PoResult.Scale(bestResult.at("b_mc_norm"));
+        BiResult.Scale(bestResult.at("a_mc"));
+        PoResult.Scale(bestResult.at("b_mc"));
 
         TH1D fakeDataHist;
         TH1D BiFit;
@@ -532,8 +513,8 @@ fitWithGlobalSystematics(){
         leg->Draw(); 
 
         TPaveText pt(0.7,0.2,1.0,0.6,"NDC");
-        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc_norm"]));
-        pt.AddText(Form("b norm = %.2f",bestResult["b_mc_norm"]));
+        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc"]));
+        pt.AddText(Form("b norm = %.2f",bestResult["b_mc"]));
         pt.AddText(Form("scaleFactor = %.2f",bestResult["scaleFactor"]));
         pt.SetFillColor(kWhite);
         pt.SetShadowColor(kWhite);
@@ -575,7 +556,7 @@ fitWithCombinedSystematics(){
     Rand::SetSeed(0);
     AxisCollection axes;
     axes.AddAxis(BinAxis("axis1", 0, 75 ,300));
-    ObsSet  obsSet(0);
+    ObsSet  obsSet("axis1");
 
     Gaussian gaus1(10, 0.5);
     Gaussian gaus2(25, 1);
@@ -653,8 +634,8 @@ fitWithCombinedSystematics(){
 
     // Setting optimisation limits
     ParameterDict minima;
-    minima["a_mc_norm"] = 10; 
-    minima["b_mc_norm"] = 10; 
+    minima["a_mc"] = 10; 
+    minima["b_mc"] = 10; 
     minima["scaleFactor" ] = 0.1;
     minima["gaus_a_1" ] = -5;
     minima["gaus_a_2" ] = 0;  
@@ -662,26 +643,17 @@ fitWithCombinedSystematics(){
     minima["gaus_b_2" ] = 0;  
 
     ParameterDict maxima;
-    maxima["a_mc_norm"] = 200000;
-    maxima["b_mc_norm"] = 200000;
+    maxima["a_mc"] = 200000;
+    maxima["b_mc"] = 200000;
     maxima["scaleFactor" ] = 2.0;    
     maxima["gaus_a_1" ] = 5;    
     maxima["gaus_a_2" ] = 5;     
     maxima["gaus_b_1" ] = 5.;   
     maxima["gaus_b_2" ] = 5;     
 
-    // ParameterDict initialval;
-    // Rand rand;
-    // initialval["a_mc_norm"] = rand.UniformRange(minima["a_mc_norm"],maxima["a_mc_norm"]); 
-    // initialval["b_mc_norm"] = rand.UniformRange(minima["b_mc_norm"],maxima["b_mc_norm"]); 
-    // initialval["gaus_a_1" ] = rand.UniformRange(minima["gaus_a_1" ],maxima["gaus_a_1" ]); 
-    // initialval["gaus_a_2" ] = rand.UniformRange(minima["gaus_a_2" ],maxima["gaus_a_2" ]); 
-    // initialval["gaus_b_1" ] = rand.UniformRange(minima["gaus_b_1" ],maxima["gaus_b_1" ]); 
-    // initialval["gaus_b_2" ] = rand.UniformRange(minima["gaus_b_2" ],maxima["gaus_b_2" ]); 
-
     ParameterDict initialval;
-    initialval["a_mc_norm"] = 90000; 
-    initialval["b_mc_norm"] = 90000; 
+    initialval["a_mc"] = 90000; 
+    initialval["b_mc"] = 90000; 
     initialval["scaleFactor"]  = 1.4;   
     initialval["gaus_a_1"]  = 0.;   
     initialval["gaus_a_2"]  = 1;    
@@ -689,8 +661,8 @@ fitWithCombinedSystematics(){
     initialval["gaus_b_2"]  = 2;    
 
     ParameterDict initialerr;
-    initialerr["a_mc_norm"] = 0.1*initialval["a_mc_norm"];
-    initialerr["b_mc_norm"] = 0.1*initialval["b_mc_norm"];
+    initialerr["a_mc"] = 0.1*initialval["a_mc"];
+    initialerr["b_mc"] = 0.1*initialval["b_mc"];
     initialerr["scaleFactor" ] = 0.1*initialval["scaleFactor"]; 
     initialerr["gaus_a_1" ] = 0.1*initialval["gaus_a_1"]; 
     initialerr["gaus_a_2" ] = 0.1*initialval["gaus_a_2"]; 
@@ -703,7 +675,7 @@ fitWithCombinedSystematics(){
 
     BinnedNLLH lh; 
     lh.SetBufferAsOverflow(false);
-    lh.SetBuffer(0,BuffLow,BuffHigh);
+    lh.SetBuffer("axis1",BuffLow,BuffHigh);
     lh.SetDataDist(fakeData); // initialise with the data set
 
     // Add the scale as a global systematic.
@@ -766,8 +738,8 @@ fitWithCombinedSystematics(){
         BiResult = BiSmearer(scale->operator()( BiHolder ));
         PoResult = PoSmearer(scale->operator()( PoHolder ));
 
-        BiResult.Scale(bestResult.at("a_mc_norm"));
-        PoResult.Scale(bestResult.at("b_mc_norm"));
+        BiResult.Scale(bestResult.at("a_mc"));
+        PoResult.Scale(bestResult.at("b_mc"));
 
         TH1D fakeDataHist;
         TH1D BiFit;
@@ -831,8 +803,8 @@ fitWithCombinedSystematics(){
         leg->Draw(); 
 
         TPaveText pt(0.7,0.2,1.0,0.7,"NDC");
-        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc_norm"]));
-        pt.AddText(Form("b norm = %.2f",bestResult["b_mc_norm"]));
+        pt.AddText(Form("a norm = %.2f" ,bestResult["a_mc"]));
+        pt.AddText(Form("b norm = %.2f",bestResult["b_mc"]));
         pt.AddText(Form("scaleFactor = %.2f",bestResult["scaleFactor"]));
         pt.AddText(Form("a conv mean = %.2f",bestResult["gaus_a_1"]));
         pt.AddText(Form("a conv RMS= %.2f",bestResult["gaus_a_2"]));

--- a/src/data/DataSetGenerator.cpp
+++ b/src/data/DataSetGenerator.cpp
@@ -51,9 +51,17 @@ DataSetGenerator::ExpectedRatesDataSet(std::vector<int>* eventsTaken_){
     dataSet.SetObservableNames(fDataSets.at(0)->GetObservableNames());
     for(size_t i = 0; i < fDataSets.size(); i++){
         unsigned expectedCounts = round(fExpectedRates.at(i));
+
+	if(fBootstraps.size() == 0)
+	  throw NotFoundError("Bootstrap flags not set for dataset");
+
 	if(fBootstraps.at(i))
 	  RandomDrawsWithReplacement(i, expectedCounts, dataSet);
 	else{
+
+	  if(fSequentialFlags.size() == 0)
+	    throw NotFoundError("Sequential flags not set for dataset");
+
 	  if(fSequentialFlags.at(i))
 	    SequentialDrawsNoReplacement(i, expectedCounts, dataSet);
 	  else
@@ -88,15 +96,22 @@ DataSetGenerator::PoissonFluctuatedDataSet(std::vector<int>* eventsTaken_){
     for(size_t i = 0; i < fDataSets.size(); i++){
         size_t counts = Rand::Poisson(fExpectedRates.at(i));
 
+	if(fBootstraps.size() == 0)
+          throw NotFoundError("Bootstrap flags not set for dataset");
+
         if(fBootstraps.at(i))
             RandomDrawsWithReplacement(i, counts, dataSet);
 
         else{
-            if(fSequentialFlags.at(i))
-                SequentialDrawsNoReplacement(i, counts, dataSet);
-            
-            else
-                RandomDrawsNoReplacement(i, counts, dataSet);
+
+	  if(fSequentialFlags.size() == 0)
+            throw NotFoundError("Sequential flags not set for dataset");
+
+	  if(fSequentialFlags.at(i))
+	    SequentialDrawsNoReplacement(i, counts, dataSet);
+
+	  else
+	    RandomDrawsNoReplacement(i, counts, dataSet);
         }
         
         if(eventsTaken_)

--- a/src/fitutil/EDManager.cpp
+++ b/src/fitutil/EDManager.cpp
@@ -69,7 +69,7 @@ EDManager::RegisterParameters(){
     fParameterManager.Clear();
     std::vector<std::string> parameterNames;
     for(size_t i = 0; i < fDists.size(); i++)
-        parameterNames.push_back(fDists.at(i)->GetName() + "_norm");
+        parameterNames.push_back(fDists.at(i)->GetName());
     
     fParameterManager.AddContainer(fNormalisations, parameterNames);
 }    

--- a/test/unit/EDManagerTest.cpp
+++ b/test/unit/EDManagerTest.cpp
@@ -66,17 +66,17 @@ TEST_CASE("Add a couple of analytic pdfs"){
 
         REQUIRE(pdfMan.GetParameterCount() == 2);
         ParameterDict testPs;
-        testPs["g1_norm"] = 0;
-        testPs["g2_norm"] = 0;
+        testPs["g1"] = 0;
+        testPs["g2"] = 0;
         REQUIRE(pdfMan.GetParameters() == testPs);
         
         std::set<std::string> expectedNames;
-        expectedNames.insert("g1_norm");
-        expectedNames.insert("g2_norm");
+        expectedNames.insert("g1");
+        expectedNames.insert("g2");
         REQUIRE(pdfMan.GetParameterNames() == expectedNames);
         
-        testPs["g1_norm"] = 10;
-        testPs["g2_norm"] = 15;
+        testPs["g1"] = 10;
+        testPs["g2"] = 15;
         pdfMan.SetParameters(testPs);
         REQUIRE(pdfMan.GetParameters()     == testPs);
         // note the line below only works because the normalisations


### PR DESCRIPTION
This PR makes minor modifications to the example macros, so that they now actually run without segfaulting. These crashes came from two problems:

- Historically, the normalisation parameter associated with a PDF in e.g. `BinnedNLLH` was the PDF name plus `"_norm"`. This feature has been changed a while ago, so that the parameter name is now just the same as the PDF name.
- Historically, the line `ObsSet  obsSet(0);` was valid; it hasn't been for a while: you now need to do something like `ObsSet  obsSet("axis1");`.

These problems have now been fixed in the examples, so that no crashes occur any more.

In addition, it was spotted that the lesser-used `EDManager` class still appended the `"_norm"`; this is different than the rest of the code. I have now modified this class to behave like `BinnedEDManager` etc.