### PR TITLE
Upgrade Catch Version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Catch"]
-	path = Catch
-	url = https://github.com/philsquared/Catch.git

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Signal Extraction framework for the SNO+ experiment
 
 6. [ROOT](https://root.cern.ch/downloading-root) Should be installed with Minuit2 enabled `./configure --enable-minuit2`
 
-7. [Catch2] (https://github.com/catchorg/Catch2) Version 3.0.0+ is needed. Install with:
+7. [Catch2](https://github.com/catchorg/Catch2) Version 3.0.0+ is needed. Install with:
    ```
    git clone git@github.com:catchorg/Catch2.git
    cd Catch2/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Signal Extraction framework for the SNO+ experiment
 <h2>Installation Instructions </h2>
 Follow the installation instructions for each of the above using either the default install location or a different directory if you would prefer. Be careful to start the install with a clean environment.
 
-1. Clone this repository with ```git clone https://github.com/snoplus/oxsx.git --recursive``` if you've already cloned without the recursive flag just run ```git submodule update --init```
+1. Clone this repository with ```git clone https://github.com/snoplus/oxsx.git```
 
 2. If your dependencies are somewhere the compiler can't find them, copy `config/userconfig.ini.template` to `config/userconfig.ini` and add the relevant paths. Missing entries are assumed to be in standard locations. e.g.
     ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Signal Extraction framework for the SNO+ experiment
 
 
 <h2> Dependencies </h2>
-1. GCC compiler capable of compiling C++ code to the C++11 standard: GCC version 4.8.5 that comes default with CentOS7 systems is good enough.
+1. GCC compiler capable of compiling C++ code to the C++17 standard
 
 2. [Armadillo](http://arma.sourceforge.net/) is a linear algebra package used for quick matrix multiplication
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ Follow the installation instructions for each of the above using either the defa
 
 4. Test the build was sucessful with ```./test/RunUnits```
 
-    If you get the error: `catch.hpp: No such file or directory` check you used the `--recursive` option when git cloning.
-
 
 <h3> Compiling Your Own Scripts</h3>
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Signal Extraction framework for the SNO+ experiment
    cmake -B build -S . -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/path/to/Catch2/
    cmake --build build/ --target install
    ```
+   (Of course, if you have permissions to write to default locations you don't necessarily need to invoke the DCMAKE_INSTALL_PREFIX option)
 
 <h2>Installation Instructions </h2>
 Follow the installation instructions for each of the above using either the default install location or a different directory if you would prefer. Be careful to start the install with a clean environment.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Signal Extraction framework for the SNO+ experiment
 
 6. [ROOT](https://root.cern.ch/downloading-root) Should be installed with Minuit2 enabled `./configure --enable-minuit2`
 
+7. [Catch2] (https://github.com/catchorg/Catch2) Version 3.0.0+ is needed. Install with:
+   ```
+   git clone git@github.com:catchorg/Catch2.git
+   cd Catch2/
+   git checkout v3.7.0 // Or whichever tag you want (must be >= 3.0.0)
+   cmake -B build -S . -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/path/to/Catch2/
+   cmake --build build/ --target install
+   ```
 
 <h2>Installation Instructions </h2>
 Follow the installation instructions for each of the above using either the default install location or a different directory if you would prefer. Be careful to start the install with a clean environment.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Signal Extraction framework for the SNO+ experiment
    cmake -B build -S . -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/path/to/Catch2/
    cmake --build build/ --target install
    ```
-   (Of course, if you have permissions to write to default locations you don't necessarily need to invoke the DCMAKE_INSTALL_PREFIX option)
+   (Of course, if you have permissions to write to default locations you don't necessarily need to invoke the `DCMAKE_INSTALL_PREFIX` option)
 
 <h2>Installation Instructions </h2>
 Follow the installation instructions for each of the above using either the default install location or a different directory if you would prefer. Be careful to start the install with a clean environment.

--- a/config/SConscript
+++ b/config/SConscript
@@ -4,7 +4,7 @@ import buildhelp
 import platform
 import os
 
-env = Environment(CXXFLAGS = "-O2 -std=c++11 -pedantic -Wall -Wextra")
+env = Environment(CXXFLAGS = "-O2 -std=c++17 -pedantic -Wall -Wextra")
 if env.GetOption('clean'):
     Return('env')
 

--- a/config/dependencies.ini
+++ b/config/dependencies.ini
@@ -14,3 +14,7 @@ libs : Core RIO Hist Gpad Tree Rint Postscript Matrix MathCore Thread pthread m 
 [gsl]
 check_headers : gsl/gsl_cdf.h
 libs : gsl gslcblas
+
+[catch2]
+check_headers : catch2/catch_all.hpp catch2/catch_approx.hpp
+libs : Catch2 Catch2Main

--- a/config/userconfig.ini.template
+++ b/config/userconfig.ini.template
@@ -14,3 +14,7 @@ lib_path    : /path/to/dir
 [gsl]
 header_path : /path/to/dir
 lib_path    : /path/to/dir
+
+[catch2]
+header_path : /path/to/dir
+lib_path    : /path/to/dir

--- a/test/unit/AxisCollectionTest.cpp
+++ b/test/unit/AxisCollectionTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <AxisCollection.h>
 
 TEST_CASE("Correct Indexing for 3x3 Uniform Axes","[AxisCollection]"){

--- a/test/unit/AxisCollectionTest.cpp
+++ b/test/unit/AxisCollectionTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <AxisCollection.h>
 

--- a/test/unit/BinAxisTest.cpp
+++ b/test/unit/BinAxisTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <BinAxis.h>
 #include <iostream>
 

--- a/test/unit/BinAxisTest.cpp
+++ b/test/unit/BinAxisTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <BinAxis.h>
 #include <iostream>

--- a/test/unit/BinnedEDGeneratorTest.cpp
+++ b/test/unit/BinnedEDGeneratorTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <BinnedEDGenerator.h>
 #include <DistTools.h>
 #include <Gaussian.h>

--- a/test/unit/BinnedEDGeneratorTest.cpp
+++ b/test/unit/BinnedEDGeneratorTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <BinnedEDGenerator.h>
 #include <DistTools.h>

--- a/test/unit/BinnedEDManagerTest.cpp
+++ b/test/unit/BinnedEDManagerTest.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Three pdfs no systematics"){
     edMan.SetNormalisations(std::vector<double>(3, 1));
 
     SECTION("Bin Probability Method"){
-      REQUIRE(edMan.BinProbability(0) == Catch::Approx(prob1 * prob2 * prob3));
+        REQUIRE(edMan.BinProbability(0) == Catch::Approx(prob1 * prob2 * prob3));
     }
     
     SECTION("Probability Method"){

--- a/test/unit/BinnedEDManagerTest.cpp
+++ b/test/unit/BinnedEDManagerTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <BinnedEDManager.h>
 #include <DistTools.h>
 #include <Gaussian.h>
@@ -34,7 +35,7 @@ TEST_CASE("Three pdfs no systematics"){
     edMan.SetNormalisations(std::vector<double>(3, 1));
 
     SECTION("Bin Probability Method"){
-        REQUIRE(edMan.BinProbability(0) == Approx(prob1 * prob2 * prob3));
+      REQUIRE(edMan.BinProbability(0) == Catch::Approx(prob1 * prob2 * prob3));
     }
     
     SECTION("Probability Method"){
@@ -43,7 +44,7 @@ TEST_CASE("Three pdfs no systematics"){
         observablesEvent.push_back("obs0");
         observablesEvent.push_back("obs1");
         ev.SetObservableNames(&observablesEvent);
-        REQUIRE(edMan.Probability(ev) == Approx(prob1 * prob2 * prob3));
+        REQUIRE(edMan.Probability(ev) == Catch::Approx(prob1 * prob2 * prob3));
     }
 
 }

--- a/test/unit/BinnedEDShrinkerTest.cpp
+++ b/test/unit/BinnedEDShrinkerTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <BinnedEDShrinker.h>
 #include <iostream>
 

--- a/test/unit/BinnedEDShrinkerTest.cpp
+++ b/test/unit/BinnedEDShrinkerTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <BinnedEDShrinker.h>
 #include <iostream>

--- a/test/unit/BinnedEDTest.cpp
+++ b/test/unit/BinnedEDTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <BinnedED.h>
 #include <Event.h>
 
@@ -22,7 +23,7 @@ TEST_CASE("Filling a 2x2 PDF"){
             pdf.Fill(vals, 0.36);
         }
 
-        REQUIRE(pdf.Integral() == Approx(100 * 0.36));
+        REQUIRE(pdf.Integral() == Catch::Approx(100 * 0.36));
         
 
         SECTION("Then Normalise"){
@@ -62,7 +63,7 @@ TEST_CASE("Filling a 2x2 PDF"){
             pdf.Fill(evData, 0.36);
         }
         
-        REQUIRE(pdf.Integral() == Approx(0.36 * 100));
+        REQUIRE(pdf.Integral() == Catch::Approx(0.36 * 100));
 
     }
 
@@ -81,7 +82,7 @@ TEST_CASE("Filling a 2x2 PDF"){
         newContent = pdf.GetBinContent(1);
 
         REQUIRE(newContent == 20.9);
-        REQUIRE(pdf.Integral() == Approx(20.9));
+        REQUIRE(pdf.Integral() == Catch::Approx(20.9));
     }
 
 }

--- a/test/unit/BinnedEDTest.cpp
+++ b/test/unit/BinnedEDTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <BinnedED.h>
 #include <Event.h>
 

--- a/test/unit/BinnedNLLHTest.cpp
+++ b/test/unit/BinnedNLLHTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <BinnedNLLH.h>
 #include <Gaussian.h>
 #include <DistTools.h>

--- a/test/unit/BinnedNLLHTest.cpp
+++ b/test/unit/BinnedNLLHTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <BinnedNLLH.h>
 #include <Gaussian.h>
 #include <DistTools.h>
@@ -51,7 +52,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         params["c"] = 1;
         lh.SetParameters(params);
         REQUIRE(lh.GetParameters() == params);
-        REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb));
+        REQUIRE(lh.Evaluate() == Catch::Approx(sumNorm + sumLogProb));
     }
     SECTION("Correct Probability with constraint"){
         lh.SetConstraint("a", 3, 1);
@@ -65,7 +66,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         params["b"] = 1;
         params["c"] = 1;
         lh.SetParameters(params);
-        REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + constraint));
+        REQUIRE(lh.Evaluate() == Catch::Approx(sumNorm + sumLogProb + constraint));
     }
     SECTION("Correct Probability with asymmetric constraint"){
         lh.SetConstraint("b", 5, 1, 2);
@@ -79,7 +80,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         params["b"] = 1;
         params["c"] = 1;
         lh.SetParameters(params);
-        REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + constraint));
+        REQUIRE(lh.Evaluate() == Catch::Approx(sumNorm + sumLogProb + constraint));
     }
     SECTION("Correct Probability with asymmetric constraint 2"){
         lh.SetConstraint("b", -3, 1, 2);
@@ -93,7 +94,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         params["b"] = 1;
         params["c"] = 1;
         lh.SetParameters(params);
-        REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + constraint));
+        REQUIRE(lh.Evaluate() == Catch::Approx(sumNorm + sumLogProb + constraint));
     }
 
     std::vector<int> genRates(3, pow(10,6));
@@ -137,7 +138,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["b"] = 1;
       params["c"] = 1;
       lh2.SetParameters(params);
-      REQUIRE(lh2.Evaluate() == Approx(sumNorm + sumLogProb + betaPen));
+      REQUIRE(lh2.Evaluate() == Catch::Approx(sumNorm + sumLogProb + betaPen));
     }
     SECTION("Correct Probability with Barlow Beeston and constraint"){
       lh2.SetConstraint("a", 3, 1);
@@ -174,7 +175,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["b"] = 1;
       params["c"] = 1;
       lh2.SetParameters(params);
-      REQUIRE(lh2.Evaluate() == Approx(sumNorm + sumLogProb + betaPen + constraint));
+      REQUIRE(lh2.Evaluate() == Catch::Approx(sumNorm + sumLogProb + betaPen + constraint));
     }
     SECTION("Correct probability with Barlow Beeston and asymmetric constraint"){
       lh2.SetConstraint("b", 5, 1, 2);
@@ -211,7 +212,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["b"] = 1;
       params["c"] = 1;
       lh2.SetParameters(params);
-      REQUIRE(lh2.Evaluate() == Approx(sumNorm + sumLogProb + betaPen + constraint));
+      REQUIRE(lh2.Evaluate() == Catch::Approx(sumNorm + sumLogProb + betaPen + constraint));
     }
     SECTION("Correct Probability with Barlow Beeston and constraint 2"){
       lh2.SetConstraint("b", -3, 1, 2);
@@ -248,6 +249,6 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["b"] = 1;
       params["c"] = 1;
       lh2.SetParameters(params);
-      REQUIRE(lh2.Evaluate() == Approx(sumNorm + sumLogProb + betaPen + constraint));
+      REQUIRE(lh2.Evaluate() == Catch::Approx(sumNorm + sumLogProb + betaPen + constraint));
     }
 }

--- a/test/unit/CatchInit.cpp
+++ b/test/unit/CatchInit.cpp
@@ -1,3 +1,2 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 

--- a/test/unit/CatchInit.cpp
+++ b/test/unit/CatchInit.cpp
@@ -1,2 +1,0 @@
-#include <catch2/catch_all.hpp>
-

--- a/test/unit/CatchInit.cpp
+++ b/test/unit/CatchInit.cpp
@@ -1,3 +1,3 @@
-#define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 

--- a/test/unit/ComponentManagerTest.cpp
+++ b/test/unit/ComponentManagerTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <ComponentManager.h>
 #include <SpectralFitDist.h>
 #include <Formatter.hpp>
@@ -52,8 +53,8 @@ TEST_CASE("Stand alone component manager"){
     }
     SECTION("getting parameter by name"){
         cmpMan.AddComponent(&pdf1);
-        REQUIRE(cmpMan.GetParameter("test1_bin_1") == Approx(0.));
+        REQUIRE(cmpMan.GetParameter("test1_bin_1") == Catch::Approx(0.));
         pdf1.SetBinContent(0, 10);
-        REQUIRE(cmpMan.GetParameter("test1_bin_0") == Approx(10.));
+        REQUIRE(cmpMan.GetParameter("test1_bin_0") == Catch::Approx(10.));
     }
 }

--- a/test/unit/ComponentManagerTest.cpp
+++ b/test/unit/ComponentManagerTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <ComponentManager.h>
 #include <SpectralFitDist.h>
 #include <Formatter.hpp>

--- a/test/unit/CompositeEDTest.cpp
+++ b/test/unit/CompositeEDTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <Gaussian.h>
 #include <BinnedED.h>
 #include <CompositeED.h>

--- a/test/unit/CompositeEDTest.cpp
+++ b/test/unit/CompositeEDTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <Gaussian.h>
 #include <BinnedED.h>
 #include <CompositeED.h>
@@ -44,14 +45,14 @@ TEST_CASE("Combining 1D gaussians", "[CompositeED]"){
 
     SECTION("Check Data Flow to internal pdfs "){
         double prob  = compositeED.Probability(ev);
-        REQUIRE(prob == Approx(0.15141173681343614));
+        REQUIRE(prob == Catch::Approx(0.15141173681343614));
         
     }
 
     SECTION("Check Clone Functionality"){
         EventDistribution* clone = compositeED.Clone();
         REQUIRE(clone -> GetNDims() == 2);
-        REQUIRE(clone -> Probability(ev) == Approx(0.15141173681343614));
+        REQUIRE(clone -> Probability(ev) == Catch::Approx(0.15141173681343614));
     }
 
     SECTION("Second level of recursion"){
@@ -61,7 +62,7 @@ TEST_CASE("Combining 1D gaussians", "[CompositeED]"){
         nextED.SetObservables(ObsSet("obs3"));
         CompositeED level2 = compositeED * nextED;
         REQUIRE( level2.GetNDims() == 3 );
-        REQUIRE( level2.Probability(ev) == Approx(0.07491808959564718));
+        REQUIRE( level2.Probability(ev) == Catch::Approx(0.07491808959564718));
                                                                                          
     }
 }

--- a/test/unit/ConstraintsTest.cpp
+++ b/test/unit/ConstraintsTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <QuadraticConstraint.h>
 #include <BivariateQuadraticConstraint.h>
 #include <ConstraintManager.h>

--- a/test/unit/ConstraintsTest.cpp
+++ b/test/unit/ConstraintsTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <QuadraticConstraint.h>
 #include <BivariateQuadraticConstraint.h>
 #include <ConstraintManager.h>
@@ -11,29 +12,29 @@ TEST_CASE("Constraints") {
     c_man.SetConstraint("a", 1, 2);
     ParameterDict params = {{"a", 2}};
     SECTION("1 Symmetric Constraint Evaluation") {
-        REQUIRE(c_man.Evaluate(params) == Approx(1./8.));
+        REQUIRE(c_man.Evaluate(params) == Catch::Approx(1./8.));
     }
     // Modify constraint to be asymmetric
     c_man.SetConstraint("a", 1, 1, 2);
     SECTION("1 Asymmetric Constraint Evaluation") {
-        REQUIRE(c_man.Evaluate(params) == Approx(1./2.));
+        REQUIRE(c_man.Evaluate(params) == Catch::Approx(1./2.));
     }
     // Add a second individual constraint
     c_man.SetConstraint("b", 10, 5);
     params["b"] = 0;
     SECTION("2 Symmetric Indiviudal Constraints Evaluation") {
-        REQUIRE(c_man.Evaluate(params) == Approx(0.5 + 2.));
+        REQUIRE(c_man.Evaluate(params) == Catch::Approx(0.5 + 2.));
     }
     // Now add a pair constraint, with no correlation
     c_man.SetConstraint("c", 0, 2, "d", 2, 10, 0);
     params["c"] = 10;
     params["d"] = 1;
     SECTION("Uncorrelated pair constraint Evaluation") {
-        REQUIRE(c_man.Evaluate(params) == Approx(0.5 + 2. + 25./2. + 1./200.));
+        REQUIRE(c_man.Evaluate(params) == Catch::Approx(0.5 + 2. + 25./2. + 1./200.));
     }
     // Modify pair constraint to handle correlation
     c_man.SetConstraint("c", 0, 2, "d", 2, 10, 0.8);
     SECTION("Uncorrelated pair constraint Evaluation") {
-        REQUIRE(c_man.Evaluate(params) == Approx(0.5 + 2. + (25./2. + 1./200. - 0.8*5*(-1./10.))/(1.- 0.8*0.8)));
+        REQUIRE(c_man.Evaluate(params) == Catch::Approx(0.5 + 2. + (25./2. + 1./200. - 0.8*5*(-1./10.))/(1.- 0.8*0.8)));
     }
 }

--- a/test/unit/CutTest.cpp
+++ b/test/unit/CutTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <BoxCut.h>
 #include <BoolCut.h>
 #include <LineCut.h>

--- a/test/unit/CutTest.cpp
+++ b/test/unit/CutTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <BoxCut.h>
 #include <BoolCut.h>

--- a/test/unit/DataSetGeneratorTest.cpp
+++ b/test/unit/DataSetGeneratorTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <OXSXDataSet.h>
 #include <DataSetGenerator.h>
 #include <iostream>

--- a/test/unit/DataSetGeneratorTest.cpp
+++ b/test/unit/DataSetGeneratorTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <OXSXDataSet.h>
 #include <DataSetGenerator.h>

--- a/test/unit/DataSetIOTest.cpp
+++ b/test/unit/DataSetIOTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <ROOTTree.h>
 #include <IO.h>
 #include <OXSXDataSet.h>

--- a/test/unit/DataSetIOTest.cpp
+++ b/test/unit/DataSetIOTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <ROOTTree.h>
 #include <IO.h>
 #include <OXSXDataSet.h>
@@ -89,8 +90,8 @@ TEST_CASE("Read TTree file in from disk") {
         for (size_t i = 0; i < intree.GetNEntries(); i++) {
             Event evt = intree.GetEntry(i);
             tree.GetEntry(i);
-            REQUIRE(evt.GetDatum("energy") == Approx(energy));
-            REQUIRE(evt.GetDatum("nhits") == Approx(static_cast<double>(nhits)));
+            REQUIRE(evt.GetDatum("energy") == Catch::Approx(energy));
+            REQUIRE(evt.GetDatum("nhits") == Catch::Approx(static_cast<double>(nhits)));
         }
     }
 

--- a/test/unit/DistToolsTest.cpp
+++ b/test/unit/DistToolsTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <DistTools.h>
 #include <BinnedED.h>
 #include <Gaussian.h>

--- a/test/unit/DistToolsTest.cpp
+++ b/test/unit/DistToolsTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <DistTools.h>
 #include <BinnedED.h>
 #include <Gaussian.h>
@@ -60,7 +61,7 @@ TEST_CASE("Converting a 1D gaussian to a binned pdf", "[DistTools]"){
     gaus.SetCdfCutOff(1E8);                                                  
     BinnedED binnedGaus("bg", DistTools::ToHist(gaus, axes));
     double intBinError  = std::abs(binnedGaus.Integral() - 1);
-    REQUIRE(intBinError == Approx(0));
+    REQUIRE(intBinError == Catch::Approx(0));
     
     SECTION("Numerical Checks"){             
         binnedGaus.Normalise();
@@ -107,9 +108,9 @@ TEST_CASE("Converting 2D gaussian to binned and marginalise", "[DistTools]"){
         REQUIRE(binnedGaus.GetNDims() == 2);
 
         // 0.5% error
-        REQUIRE(integralError == Approx(0));
-        REQUIRE(mean1Error == Approx(0));
-        REQUIRE(mean2Error == Approx(0));
+        REQUIRE(integralError == Catch::Approx(0));
+        REQUIRE(mean1Error == Catch::Approx(0));
+        REQUIRE(mean2Error == Catch::Approx(0));
 
         // binning tends to give an error on the varaince 0.1% becuase rms != sigma
         REQUIRE(stDev1Error/20/20 < 0.004);
@@ -135,11 +136,11 @@ TEST_CASE("Converting 2D gaussian to binned and marginalise", "[DistTools]"){
         double xVarEr = std::abs(xProj.Variances().at(0) - 20 * 20);
         double yVarEr = std::abs(yProj.Variances().at(0) - 30 * 30);
 
-        REQUIRE(xProj.Integral() == Approx(1));
-        REQUIRE(yProj.Integral() == Approx(1));
+        REQUIRE(xProj.Integral() == Catch::Approx(1));
+        REQUIRE(yProj.Integral() == Catch::Approx(1));
 
-        REQUIRE(xMean == Approx(0));
-        REQUIRE(yMean == Approx(10));
+        REQUIRE(xMean == Catch::Approx(0));
+        REQUIRE(yMean == Catch::Approx(10));
 
         REQUIRE(xVarEr/20/20 < 0.004);
         REQUIRE(yVarEr/30/30 < 0.004);

--- a/test/unit/EDManagerTest.cpp
+++ b/test/unit/EDManagerTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <EDManager.h>
 #include <Gaussian.h>
 #include <AnalyticED.h>
@@ -56,7 +57,7 @@ TEST_CASE("Add a couple of analytic pdfs"){
         REQUIRE(pdfMan.Probability(event) == 0); // norms are zero
 
         pdfMan.SetNormalisations(std::vector<double>(2, 1));
-        REQUIRE(pdfMan.Probability(event) == Approx(0.7978845607));
+        REQUIRE(pdfMan.Probability(event) == Catch::Approx(0.7978845607));
         // 0.7978845607 = 2 /sqrt(2 * pi)
     }
 

--- a/test/unit/EDManagerTest.cpp
+++ b/test/unit/EDManagerTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <EDManager.h>
 #include <Gaussian.h>
 #include <AnalyticED.h>

--- a/test/unit/EventScaleTest.cpp
+++ b/test/unit/EventScaleTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <Event.h>
 #include <EventScale.h>

--- a/test/unit/EventScaleTest.cpp
+++ b/test/unit/EventScaleTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <Event.h>
 #include <EventScale.h>
 

--- a/test/unit/EventShiftTest.cpp
+++ b/test/unit/EventShiftTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <Event.h>
 #include <EventShift.h>
 

--- a/test/unit/EventShiftTest.cpp
+++ b/test/unit/EventShiftTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <Event.h>
 #include <EventShift.h>

--- a/test/unit/EventSystematicManagerTest.cpp
+++ b/test/unit/EventSystematicManagerTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <EventSystematicManager.h>
 #include <EventScale.h>
 #include <EventShift.h>

--- a/test/unit/EventSystematicManagerTest.cpp
+++ b/test/unit/EventSystematicManagerTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <EventSystematicManager.h>
 #include <EventScale.h>

--- a/test/unit/FitParameterTest.cpp
+++ b/test/unit/FitParameterTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <ContainerParameter.h>
 #include <DoubleParameter.h>
 #include <list>

--- a/test/unit/FitParameterTest.cpp
+++ b/test/unit/FitParameterTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <ContainerParameter.h>
 #include <DoubleParameter.h>

--- a/test/unit/GaussianFitterTest.cpp
+++ b/test/unit/GaussianFitterTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <Gaussian.h>
 #include <ParameterDict.h>
 #include <iostream>

--- a/test/unit/GaussianFitterTest.cpp
+++ b/test/unit/GaussianFitterTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <Gaussian.h>
 #include <ParameterDict.h>

--- a/test/unit/GaussianTest.cpp
+++ b/test/unit/GaussianTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <Gaussian.h>
 #include <iostream>
 
@@ -38,22 +39,22 @@ TEST_CASE("1D gaussian", "[Gaussian]"){
     }
 
     SECTION("Check probability"){
-        REQUIRE(gaus(std::vector<double>(1,1)) == Approx(0.24197));
-        REQUIRE(gaus(std::vector<double> (1,1E8)) == Approx(0));
-        REQUIRE(gaus(std::vector<double> (1,-1E8)) == Approx(0));
+        REQUIRE(gaus(std::vector<double>(1,1)) == Catch::Approx(0.24197));
+        REQUIRE(gaus(std::vector<double> (1,1E8)) == Catch::Approx(0));
+        REQUIRE(gaus(std::vector<double> (1,-1E8)) == Catch::Approx(0));
     }
 
 
     SECTION("Test CDF"){
-        REQUIRE(gaus.Cdf(0, 1) == Approx(0.841344));
-        REQUIRE(gaus.Cdf(0, 100) == Approx(1));
-        REQUIRE(gaus.Cdf(0, -100) == Approx(0));
+        REQUIRE(gaus.Cdf(0, 1) == Catch::Approx(0.841344));
+        REQUIRE(gaus.Cdf(0, 100) == Catch::Approx(1));
+        REQUIRE(gaus.Cdf(0, -100) == Catch::Approx(0));
     }
 
     SECTION("Test Integral"){
-        REQUIRE(gaus.Integral(std::vector<double>(1,-1),std::vector<double>(1,1)) == Approx(0.6827));
-        REQUIRE(gaus.Integral(std::vector<double>(1, -100), std::vector<double>(1, 100)) == Approx(1));
-        REQUIRE(gaus.Integral(std::vector<double>(1,0), std::vector<double>(1,0)) == Approx(0));
+        REQUIRE(gaus.Integral(std::vector<double>(1,-1),std::vector<double>(1,1)) == Catch::Approx(0.6827));
+        REQUIRE(gaus.Integral(std::vector<double>(1, -100), std::vector<double>(1, 100)) == Catch::Approx(1));
+        REQUIRE(gaus.Integral(std::vector<double>(1,0), std::vector<double>(1,0)) == Catch::Approx(0));
     }
 }
 

--- a/test/unit/GaussianTest.cpp
+++ b/test/unit/GaussianTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <Gaussian.h>
 #include <iostream>
 

--- a/test/unit/HistToolsTest.cpp
+++ b/test/unit/HistToolsTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <HistTools.h>
 #include <BinAxis.h>
 #include <Histogram.h>

--- a/test/unit/HistToolsTest.cpp
+++ b/test/unit/HistToolsTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <HistTools.h>
 #include <BinAxis.h>

--- a/test/unit/HistogramGetMultiDSlice.cpp
+++ b/test/unit/HistogramGetMultiDSlice.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <Histogram.h>
 #include <cstdlib>
 #include <iostream>

--- a/test/unit/HistogramGetMultiDSlice.cpp
+++ b/test/unit/HistogramGetMultiDSlice.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <Histogram.h>
 #include <cstdlib>

--- a/test/unit/HistogramIOTest.cpp
+++ b/test/unit/HistogramIOTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <IO.h>
 #include <Histogram.h>

--- a/test/unit/HistogramIOTest.cpp
+++ b/test/unit/HistogramIOTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <IO.h>
 #include <Histogram.h>
 #include <Combinations.hpp>

--- a/test/unit/ObservableSetTest.cpp
+++ b/test/unit/ObservableSetTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <ObsSet.h>
 #include <OXSXDataSet.h>
 

--- a/test/unit/ObservableSetTest.cpp
+++ b/test/unit/ObservableSetTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <ObsSet.h>
 #include <OXSXDataSet.h>

--- a/test/unit/ParameterManagerTest.cpp
+++ b/test/unit/ParameterManagerTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <list>
 #include <ParameterManager.h>

--- a/test/unit/ParameterManagerTest.cpp
+++ b/test/unit/ParameterManagerTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <list>
 #include <ParameterManager.h>
 #include <DoubleParameter.h>

--- a/test/unit/SConscript
+++ b/test/unit/SConscript
@@ -5,9 +5,9 @@ Import('lib')
 # scons needs catch (unit test framework) and the new build
 # for tests
 testenv = env.Clone()
-testenv.Append(CPPPATH = "#/Catch/include")
-testenv.Append(LIBS = "oxsx")
-testenv.Append(LIBPATH = "#/build")
+testenv.Append(CPPPATH = "#/Catch2/include")
+testenv.Append(LIBPATH = ["#/build","#/Catch2/lib64"])
+testenv.Append(LIBS = ["oxsx","Catch2Main", "Catch2"])
 
 # make the object files
 unit_test_files = Glob("*/*.cpp") + Glob("*.cpp")

--- a/test/unit/SConscript
+++ b/test/unit/SConscript
@@ -2,19 +2,12 @@
 Import('env')
 Import('lib')
 
-# scons needs catch (unit test framework) and the new build
-# for tests
-testenv = env.Clone()
-testenv.Append(CPPPATH = "#/Catch2/include")
-testenv.Append(LIBPATH = ["#/build","#/Catch2/lib64"])
-testenv.Append(LIBS = ["oxsx","Catch2Main", "Catch2"])
-
 # make the object files
 unit_test_files = Glob("*/*.cpp") + Glob("*.cpp")
 
-unit_tests      = [testenv.Object(x) for x in unit_test_files]
-unit_test_executible = testenv.Program("#/test/RunUnits", 
+unit_tests      = [env.Object(x) for x in unit_test_files]
+unit_test_executible = env.Program("#/test/RunUnits", 
                                        source = [unit_tests, lib],
                                        )
 
-testenv.Alias("units", unit_test_executible)
+env.Alias("units", unit_test_executible)

--- a/test/unit/ScaleFuncSystTest.cpp
+++ b/test/unit/ScaleFuncSystTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <SystematicManager.h>
 #include <ScaleFunction.h>
 
@@ -127,6 +128,6 @@ TEST_CASE("Another simple ScaleFunction systematic on 2d PDF"){
     correctVals[axes.FlattenIndices({4,1})] = 2;
     
     for (size_t i=0; i<modifiedObs.size(); i++) {
-        REQUIRE(modifiedObs.at(i) == Approx(correctVals.at(i)));
+        REQUIRE(modifiedObs.at(i) == Catch::Approx(correctVals.at(i)));
     }
 }

--- a/test/unit/ScaleFuncSystTest.cpp
+++ b/test/unit/ScaleFuncSystTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <SystematicManager.h>
 #include <ScaleFunction.h>
 

--- a/test/unit/ScaleSystTest.cpp
+++ b/test/unit/ScaleSystTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <SystematicManager.h>
 #include <Scale.h>
 
@@ -88,7 +89,7 @@ TEST_CASE("Another simple scale systematic on 2d PDF"){
     correctVals[axes.FlattenIndices({3,1})] = 6;
     
     for (size_t i=0; i<modifiedObs.size(); i++) {
-        REQUIRE(modifiedObs.at(i) == Approx(correctVals.at(i)));
+        REQUIRE(modifiedObs.at(i) == Catch::Approx(correctVals.at(i)));
     }
 }
 
@@ -135,6 +136,6 @@ TEST_CASE("Another simple scale systematic on 3d PDF"){
     correctVals[axes.FlattenIndices({3,1,3})] = 6;
     
     for (size_t i=0; i<modifiedObs.size(); i++) {
-        REQUIRE(modifiedObs.at(i) == Approx(correctVals.at(i)));
+        REQUIRE(modifiedObs.at(i) == Catch::Approx(correctVals.at(i)));
     }
 }

--- a/test/unit/ScaleSystTest.cpp
+++ b/test/unit/ScaleSystTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <SystematicManager.h>
 #include <Scale.h>
 

--- a/test/unit/ShapeTest.cpp
+++ b/test/unit/ShapeTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <Shape.h>
 #include <ParameterDict.h>
 #include <Gaussian.h>
@@ -112,7 +113,7 @@ TEST_CASE("Shape") {
         
         lh.SetParameters({{"back", 1}, {"a", 1}, {"b", 1000}});
 
-        REQUIRE(lh.Evaluate() == Approx(sum_log_prob + sum_norm));
+        REQUIRE(lh.Evaluate() == Catch::Approx(sum_log_prob + sum_norm));
 
         // Now change params, and check if lh can still handle it!
         lh.SetParameters({{"back", 2}, {"a", 1}, {"b", 500}});
@@ -125,6 +126,6 @@ TEST_CASE("Shape") {
         sum_log_prob = -log(prob_back + prob_sig);
         sum_norm = shape_norm_factor + 2.;
 
-        REQUIRE(lh.Evaluate() == Approx(sum_log_prob + sum_norm));
+        REQUIRE(lh.Evaluate() == Catch::Approx(sum_log_prob + sum_norm));
     }
 }

--- a/test/unit/ShapeTest.cpp
+++ b/test/unit/ShapeTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <Shape.h>
 #include <ParameterDict.h>
 #include <Gaussian.h>

--- a/test/unit/ShiftSystTest.cpp
+++ b/test/unit/ShiftSystTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <SystematicManager.h>
 #include <Shift.h>
 

--- a/test/unit/ShiftSystTest.cpp
+++ b/test/unit/ShiftSystTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <SystematicManager.h>
 #include <Shift.h>

--- a/test/unit/SpectralFitDistTest.cpp
+++ b/test/unit/SpectralFitDistTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <Formatter.hpp>
 #include <ContainerTools.hpp>
 #include <SpectralFitDist.h>

--- a/test/unit/SpectralFitDistTest.cpp
+++ b/test/unit/SpectralFitDistTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <Formatter.hpp>
 #include <ContainerTools.hpp>

--- a/test/unit/SquareRootScaleTest.cpp
+++ b/test/unit/SquareRootScaleTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <SquareRootScale.h>
 #include <iostream>
 

--- a/test/unit/SquareRootScaleTest.cpp
+++ b/test/unit/SquareRootScaleTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <SquareRootScale.h>
 #include <iostream>

--- a/test/unit/StatisticSumTest.cpp
+++ b/test/unit/StatisticSumTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
 #include <StatisticSum.h>
 #include <BinnedNLLH.h>

--- a/test/unit/StatisticSumTest.cpp
+++ b/test/unit/StatisticSumTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <StatisticSum.h>
 #include <BinnedNLLH.h>
 

--- a/test/unit/SystematicManagerTest.cpp
+++ b/test/unit/SystematicManagerTest.cpp
@@ -1,5 +1,6 @@
+#include <catch2/catch_approx.hpp>
 //The point of this is to test the interace no do a fit.
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <BinnedEDManager.h>
 #include <DistTools.h>
 #include <Gaussian.h>

--- a/test/unit/SystematicManagerTest.cpp
+++ b/test/unit/SystematicManagerTest.cpp
@@ -1,4 +1,3 @@
-#include <catch2/catch_approx.hpp>
 //The point of this is to test the interace no do a fit.
 #include <catch2/catch_all.hpp>
 #include <BinnedEDManager.h>

--- a/test/unit/VaryingCDFTest.cpp
+++ b/test/unit/VaryingCDFTest.cpp
@@ -140,7 +140,7 @@ TEST_CASE("Varying CDF 2 parameter TWO", "[VaryingCDF]"){
 
     SECTION("Check probability"){
         // You are centered at 1, the mean shifts by 2 there the gaussian is about 3  with a stddev of 1. Therefore integrate between [2,4].
-        REQUIRE(smearer.Integral(std::vector<double>(1,2),std::vector<double>(1,4),std::vector<double>(1,1))==Catch::Approx(0.6827).epsilon(0.1));
+        REQUIRE(smearer.Integral(std::vector<double>(1,2),std::vector<double>(1,4),std::vector<double>(1,1))==Catch::Approx(0.6827));
     }
 }
 

--- a/test/unit/VaryingCDFTest.cpp
+++ b/test/unit/VaryingCDFTest.cpp
@@ -1,5 +1,5 @@
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
 #include <iostream>
 
 #include <VaryingCDF.h>

--- a/test/unit/VaryingCDFTest.cpp
+++ b/test/unit/VaryingCDFTest.cpp
@@ -1,4 +1,5 @@
-#include <catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_all.hpp>
 #include <iostream>
 
 #include <VaryingCDF.h>
@@ -108,8 +109,8 @@ TEST_CASE("Varying CDF 1 Parameter", "[VaryingCDF]"){
         REQUIRE(smearer.GetName()=="smearer");
     }
     SECTION("Check probability"){
-        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1))==Approx(0.6827));
-        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2))==Approx(0.6827));
+        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1))==Catch::Approx(0.6827));
+        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2))==Catch::Approx(0.6827));
     }
 }
 
@@ -123,8 +124,8 @@ TEST_CASE("Varying CDF 2 parameter", "[VaryingCDF]"){
     smearer.SetDependance("stddevs_0",&ployStd);
 
     SECTION("Check probability"){
-        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1))==Approx(0.6827));
-        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2))==Approx(0.6827));
+        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1))==Catch::Approx(0.6827));
+        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2))==Catch::Approx(0.6827));
     }
 }
 
@@ -139,7 +140,7 @@ TEST_CASE("Varying CDF 2 parameter TWO", "[VaryingCDF]"){
 
     SECTION("Check probability"){
         // You are centered at 1, the mean shifts by 2 there the gaussian is about 3  with a stddev of 1. Therefore integrate between [2,4].
-        REQUIRE(smearer.Integral(std::vector<double>(1,2),std::vector<double>(1,4),std::vector<double>(1,1))==Approx(0.6827));
+        REQUIRE(smearer.Integral(std::vector<double>(1,2),std::vector<double>(1,4),std::vector<double>(1,1))==Catch::Approx(0.6827).epsilon(0.1));
     }
 }
 


### PR DESCRIPTION
As stated in [Issue 45](https://github.com/snoplus/oxsx/issues/45) the Catch2 commit (Catch2 ~v1) we use was no longer compatible with modern compilers. This pull request changes our use of Catch2 to the latest version.

It was a bit more of a headache than I'd hoped, because from v3 onwards you have to compile Catch2 and not just use a single include file. Catch2 v2 was also seemingly not c++17 compatible, but I think for different reasons than v1.

So I've removed our Catch2 ~v1 submodule, and instead added Catch2 v3 as a standard dependency in line with ROOT etc. The user updates the paths to their Catch2 install using `config/userconfig.ini` in the normal way, and I've added installation instructions to the README. We don't do full installation instructions for the other dependencies, so it's a bit incongruous, but I think useful.

The unit test SConscript is updated to no longer need the old Catch2 submodule. The downside of this is you now can't install the rest of OXO without Catch2, but I think we shouldn't encourage users to install without running the tests! Maybe it's now not necessary to have the unit tests compiled with a separate SCons file, but I'm inclined to keep it as it is. I don't think there's much of a downside to compiling them separately, and there's an argument it's natural to do so (but could be persuaded otherwise).

For the actual tests, the only changes currently are to replace the include with a different header file, include the `Approx` header if using `Approx`, and also change that to `Catch2::Approx`. Easy.


"But why do I feel like there's something you're not telling me, Bill?"

OK the real tricky bit was that having done all this, the tests fail for several calls of `Catch2::Approx`. After several hours in the depths of the Catch2 source code, and concluding that, despite having wildly different implementations between v1 and v3, the approximation checks were functionally still the same, and the values being supplied to compare were the same, I was very stumped. (Un?)fortunately it turned out I'd misread the documentation and the default value of one of the parameters related to the tolerance of the approximation had changed. There's several that are 1 or 0, and one changed from 1 to 0 🙈 

The details are a bit fiddly so I'll save the actual workaround for a discussion in the OXO call (we just update that parameter, or set the overall tolerance a bit higher). But the machinery change to v3 can be reviewed.

P.S: excuse the slightly sloppy git usage, this does build off #47 !