### PR TITLE
unit test fixes

### DIFF
--- a/test/unit/BinnedEDGeneratorTest.cpp
+++ b/test/unit/BinnedEDGeneratorTest.cpp
@@ -19,8 +19,8 @@ TEST_CASE("Recover a 1D gaussian"){
     REQUIRE(outPdf.Integral() == 1000000);
     outPdf.Normalise();
 
-    double outMean = outPdf.Means().at(0);
-    double inMean = inPdf.Means().at(0);
+    const double outMean = outPdf.Means().at(0);
+    const double inMean = inPdf.Means().at(0);
 
-    REQUIRE(std::abs(outMean) < 0.01);
+    REQUIRE_THAT(outMean, Catch::Matchers::WithinAbs(inMean, 0.01));
 }

--- a/test/unit/BinnedEDTest.cpp
+++ b/test/unit/BinnedEDTest.cpp
@@ -69,7 +69,7 @@ TEST_CASE("Filling a 2x2 PDF"){
 
 
     SECTION("Bin Content initialisation and setting"){
-        double initialContent = pdf.GetBinContent(1);
+        const double initialContent = pdf.GetBinContent(1);
 
         REQUIRE(initialContent == 0);
         
@@ -77,12 +77,12 @@ TEST_CASE("Filling a 2x2 PDF"){
         double newContent = pdf.GetBinContent(1);
         REQUIRE(newContent == 10.01);
 
-        double setContent = 20.9;
-        pdf.SetBinContent(1, 20.9);
+        const double setContent = 20.9;
+        pdf.SetBinContent(1, setContent);
         newContent = pdf.GetBinContent(1);
 
-        REQUIRE(newContent == 20.9);
-        REQUIRE(pdf.Integral() == Catch::Approx(20.9));
+        REQUIRE(newContent == setContent);
+        REQUIRE_THAT(pdf.Integral(), Catch::Matchers::WithinAbs(setContent, 0.0001));
     }
 
 }

--- a/test/unit/BinnedNLLHTest.cpp
+++ b/test/unit/BinnedNLLHTest.cpp
@@ -52,7 +52,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         params["c"] = 1;
         lh.SetParameters(params);
         REQUIRE(lh.GetParameters() == params);
-        REQUIRE(lh.Evaluate() == Catch::Approx(sumNorm + sumLogProb));
+        REQUIRE_THAT(lh.Evaluate(), Catch::Matchers::WithinAbs(sumNorm + sumLogProb, 0.0001));
     }
     SECTION("Correct Probability with constraint"){
         lh.SetConstraint("a", 3, 1);
@@ -66,7 +66,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         params["b"] = 1;
         params["c"] = 1;
         lh.SetParameters(params);
-        REQUIRE(lh.Evaluate() == Catch::Approx(sumNorm + sumLogProb + constraint));
+        REQUIRE_THAT(lh.Evaluate(), Catch::Matchers::WithinAbs(sumNorm + sumLogProb + constraint, 0.0001));
     }
     SECTION("Correct Probability with asymmetric constraint"){
         lh.SetConstraint("b", 5, 1, 2);
@@ -80,7 +80,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         params["b"] = 1;
         params["c"] = 1;
         lh.SetParameters(params);
-        REQUIRE(lh.Evaluate() == Catch::Approx(sumNorm + sumLogProb + constraint));
+        REQUIRE_THAT(lh.Evaluate(), Catch::Matchers::WithinAbs(sumNorm + sumLogProb + constraint, 0.0001));
     }
     SECTION("Correct Probability with asymmetric constraint 2"){
         lh.SetConstraint("b", -3, 1, 2);
@@ -94,7 +94,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         params["b"] = 1;
         params["c"] = 1;
         lh.SetParameters(params);
-        REQUIRE(lh.Evaluate() == Catch::Approx(sumNorm + sumLogProb + constraint));
+        REQUIRE_THAT(lh.Evaluate(), Catch::Matchers::WithinAbs(sumNorm + sumLogProb + constraint, 0.0001));
     }
 
     std::vector<int> genRates(3, pow(10,6));
@@ -138,7 +138,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["b"] = 1;
       params["c"] = 1;
       lh2.SetParameters(params);
-      REQUIRE(lh2.Evaluate() == Catch::Approx(sumNorm + sumLogProb + betaPen));
+      REQUIRE_THAT(lh2.Evaluate(), Catch::Matchers::WithinAbs(sumNorm + sumLogProb + betaPen, 0.0001));
     }
     SECTION("Correct Probability with Barlow Beeston and constraint"){
       lh2.SetConstraint("a", 3, 1);
@@ -175,7 +175,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["b"] = 1;
       params["c"] = 1;
       lh2.SetParameters(params);
-      REQUIRE(lh2.Evaluate() == Catch::Approx(sumNorm + sumLogProb + betaPen + constraint));
+      REQUIRE_THAT(lh2.Evaluate(), Catch::Matchers::WithinAbs(sumNorm + sumLogProb + betaPen + constraint, 0.0001));
     }
     SECTION("Correct probability with Barlow Beeston and asymmetric constraint"){
       lh2.SetConstraint("b", 5, 1, 2);
@@ -212,7 +212,7 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["b"] = 1;
       params["c"] = 1;
       lh2.SetParameters(params);
-      REQUIRE(lh2.Evaluate() == Catch::Approx(sumNorm + sumLogProb + betaPen + constraint));
+      REQUIRE_THAT(lh2.Evaluate(), Catch::Matchers::WithinAbs(sumNorm + sumLogProb + betaPen + constraint, 0.0001));
     }
     SECTION("Correct Probability with Barlow Beeston and constraint 2"){
       lh2.SetConstraint("b", -3, 1, 2);
@@ -249,6 +249,6 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
       params["b"] = 1;
       params["c"] = 1;
       lh2.SetParameters(params);
-      REQUIRE(lh2.Evaluate() == Catch::Approx(sumNorm + sumLogProb + betaPen + constraint));
+      REQUIRE_THAT(lh2.Evaluate(), Catch::Matchers::WithinAbs(sumNorm + sumLogProb + betaPen + constraint, 0.0001));
     }
 }

--- a/test/unit/DataSetGeneratorTest.cpp
+++ b/test/unit/DataSetGeneratorTest.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Dataset generation by random draws"){
     bootstraps.push_back(false);
     gen.SetBootstrap(bootstraps);
     OXSXDataSet newDataSet = gen.ExpectedRatesDataSet();
-    REQUIRE(newDataSet.GetNEntries() == std::accumulate(rates.begin(), rates.end(), 0));
+    REQUIRE(int(newDataSet.GetNEntries()) == std::accumulate(rates.begin(), rates.end(), 0));
   }
   
 
@@ -73,7 +73,7 @@ TEST_CASE("Dataset generation by random draws"){
     bootstraps.push_back(true);
     gen.SetBootstrap(bootstraps);
     OXSXDataSet newDataSet = gen.ExpectedRatesDataSet();
-    REQUIRE(newDataSet.GetNEntries() == std::accumulate(rates.begin(), rates.end(), 0));
+    REQUIRE(int(newDataSet.GetNEntries()) == std::accumulate(rates.begin(), rates.end(), 0));
   }
 
 

--- a/test/unit/DistToolsTest.cpp
+++ b/test/unit/DistToolsTest.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Converting a 1D gaussian to a binned pdf", "[DistTools]"){
     gaus.SetCdfCutOff(1E8);                                                  
     BinnedED binnedGaus("bg", DistTools::ToHist(gaus, axes));
     double intBinError  = std::abs(binnedGaus.Integral() - 1);
-    REQUIRE(intBinError == Catch::Approx(0));
+    REQUIRE_THAT(intBinError, Catch::Matchers::WithinAbs(0, 0.0001));
     
     SECTION("Numerical Checks"){             
         binnedGaus.Normalise();
@@ -108,9 +108,9 @@ TEST_CASE("Converting 2D gaussian to binned and marginalise", "[DistTools]"){
         REQUIRE(binnedGaus.GetNDims() == 2);
 
         // 0.5% error
-        REQUIRE(integralError == Catch::Approx(0));
-        REQUIRE(mean1Error == Catch::Approx(0));
-        REQUIRE(mean2Error == Catch::Approx(0));
+        REQUIRE_THAT(integralError, Catch::Matchers::WithinAbs(0, 0.0001));
+        REQUIRE_THAT(mean1Error, Catch::Matchers::WithinAbs(0, 0.0001));
+        REQUIRE_THAT(mean2Error, Catch::Matchers::WithinAbs(0, 0.0001));
 
         // binning tends to give an error on the varaince 0.1% becuase rms != sigma
         REQUIRE(stDev1Error/20/20 < 0.004);
@@ -136,11 +136,11 @@ TEST_CASE("Converting 2D gaussian to binned and marginalise", "[DistTools]"){
         double xVarEr = std::abs(xProj.Variances().at(0) - 20 * 20);
         double yVarEr = std::abs(yProj.Variances().at(0) - 30 * 30);
 
-        REQUIRE(xProj.Integral() == Catch::Approx(1));
-        REQUIRE(yProj.Integral() == Catch::Approx(1));
+        REQUIRE_THAT(xProj.Integral(), Catch::Matchers::WithinAbs(1, 0.0001));
+        REQUIRE_THAT(yProj.Integral(), Catch::Matchers::WithinAbs(1, 0.0001));
 
-        REQUIRE(xMean == Catch::Approx(0));
-        REQUIRE(yMean == Catch::Approx(10));
+        REQUIRE_THAT(xMean, Catch::Matchers::WithinAbs(0, 0.0001));
+        REQUIRE_THAT(yMean, Catch::Matchers::WithinAbs(10, 0.0001));
 
         REQUIRE(xVarEr/20/20 < 0.004);
         REQUIRE(yVarEr/30/30 < 0.004);

--- a/test/unit/GaussianTest.cpp
+++ b/test/unit/GaussianTest.cpp
@@ -39,22 +39,22 @@ TEST_CASE("1D gaussian", "[Gaussian]"){
     }
 
     SECTION("Check probability"){
-        REQUIRE(gaus(std::vector<double>(1,1)) == Catch::Approx(0.24197));
-        REQUIRE(gaus(std::vector<double> (1,1E8)) == Catch::Approx(0));
-        REQUIRE(gaus(std::vector<double> (1,-1E8)) == Catch::Approx(0));
+        REQUIRE_THAT(gaus(std::vector<double>(1,1)), Catch::Matchers::WithinAbs(0.24197, 0.0001));
+        REQUIRE_THAT(gaus(std::vector<double> (1,1E8)), Catch::Matchers::WithinAbs(0, 0.0001));
+        REQUIRE_THAT(gaus(std::vector<double> (1,-1E8)), Catch::Matchers::WithinAbs(0, 0.0001));
     }
 
 
     SECTION("Test CDF"){
-        REQUIRE(gaus.Cdf(0, 1) == Catch::Approx(0.841344));
-        REQUIRE(gaus.Cdf(0, 100) == Catch::Approx(1));
-        REQUIRE(gaus.Cdf(0, -100) == Catch::Approx(0));
+        REQUIRE_THAT(gaus.Cdf(0, 1), Catch::Matchers::WithinAbs(0.841344, 0.0001));
+        REQUIRE_THAT(gaus.Cdf(0, 100), Catch::Matchers::WithinAbs(1, 0.0001));
+        REQUIRE_THAT(gaus.Cdf(0, -100), Catch::Matchers::WithinAbs(0, 0.0001));
     }
 
     SECTION("Test Integral"){
-        REQUIRE(gaus.Integral(std::vector<double>(1,-1),std::vector<double>(1,1)) == Catch::Approx(0.6827));
-        REQUIRE(gaus.Integral(std::vector<double>(1, -100), std::vector<double>(1, 100)) == Catch::Approx(1));
-        REQUIRE(gaus.Integral(std::vector<double>(1,0), std::vector<double>(1,0)) == Catch::Approx(0));
+        REQUIRE_THAT(gaus.Integral(std::vector<double>(1,-1),std::vector<double>(1,1)), Catch::Matchers::WithinAbs(0.6827, 0.0001));
+        REQUIRE_THAT(gaus.Integral(std::vector<double>(1, -100), std::vector<double>(1, 100)), Catch::Matchers::WithinAbs(1, 0.0001));
+        REQUIRE_THAT(gaus.Integral(std::vector<double>(1,0), std::vector<double>(1,0)), Catch::Matchers::WithinAbs(0, 0.0001));
     }
 }
 

--- a/test/unit/HistogramGetMultiDSlice.cpp
+++ b/test/unit/HistogramGetMultiDSlice.cpp
@@ -34,8 +34,7 @@ TEST_CASE("Multi-Dimensional Histogram Slicing"){
         Histogram dim1 = origHistogram.GetSlice(fixedBins);
         
         // grab the axis & total bin number in slice for later testing  
-        BinAxis newAx = dim1.GetAxes().GetAxis(0); 
-        size_t numBins = dim1.GetNBins(); 
+        BinAxis newAx = dim1.GetAxes().GetAxis(0);
 
         // CODE TO VERIFY BIN CONTENTS OF SLICE IS CORRECT 
         // vector stores the local idx for each bin in slice for each axis 

--- a/test/unit/VaryingCDFTest.cpp
+++ b/test/unit/VaryingCDFTest.cpp
@@ -109,8 +109,8 @@ TEST_CASE("Varying CDF 1 Parameter", "[VaryingCDF]"){
         REQUIRE(smearer.GetName()=="smearer");
     }
     SECTION("Check probability"){
-        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1))==Catch::Approx(0.6827));
-        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2))==Catch::Approx(0.6827));
+        REQUIRE_THAT(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1)), Catch::Matchers::WithinAbs(0.6827, 0.0001));
+        REQUIRE_THAT(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2)), Catch::Matchers::WithinAbs(0.6827, 0.0001));
     }
 }
 
@@ -124,8 +124,8 @@ TEST_CASE("Varying CDF 2 parameter", "[VaryingCDF]"){
     smearer.SetDependance("stddevs_0",&ployStd);
 
     SECTION("Check probability"){
-        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1))==Catch::Approx(0.6827));
-        REQUIRE(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2))==Catch::Approx(0.6827));
+        REQUIRE_THAT(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,2),std::vector<double>(1,1)), Catch::Matchers::WithinAbs(0.6827, 0.0001));
+        REQUIRE_THAT(smearer.Integral(std::vector<double>(1,0),std::vector<double>(1,4),std::vector<double>(1,2)), Catch::Matchers::WithinAbs(0.6827, 0.0001));
     }
 }
 
@@ -140,7 +140,7 @@ TEST_CASE("Varying CDF 2 parameter TWO", "[VaryingCDF]"){
 
     SECTION("Check probability"){
         // You are centered at 1, the mean shifts by 2 there the gaussian is about 3  with a stddev of 1. Therefore integrate between [2,4].
-        REQUIRE(smearer.Integral(std::vector<double>(1,2),std::vector<double>(1,4),std::vector<double>(1,1))==Catch::Approx(0.6827));
+        REQUIRE_THAT(smearer.Integral(std::vector<double>(1,2),std::vector<double>(1,4),std::vector<double>(1,1)), Catch::Matchers::WithinAbs(0.6827, 0.0001));
     }
 }
 


### PR DESCRIPTION
With the upgrade to Catch2 v3, how Catch's `Catch::Approx()` method handled tolerances changed, leading to a bunch of previously-passing unit tests suddenly.

This PR fixes these, now using the new recommended syntax of:
```
REQUIRE_THAT(test_val, Catch::Matchers::WithinAbs(exp_val, tolerance));
```

I have used a tolerance of 0.0001 throughout; all unit tests now pass.

In addition, there were a few places during compilation of the unit tests where the upgrade to C++17 led to new warnings. Those warnings have now been dealt with.

As a result of this PR (on top of the work of the previous two PRs!), we can now compile this repo's unit tests in C++17, and have all unit tests pass.