### PR TITLE
Allow user to specify empty string for systematics group

### DIFF
--- a/src/fitutil/SystematicManager.cpp
+++ b/src/fitutil/SystematicManager.cpp
@@ -55,8 +55,10 @@ SystematicManager::GetTotalResponse(const std::string &groupName_) const
 
 void SystematicManager::Add(Systematic *sys_, const std::string &groupName_)
 {
-    if (groupName_ == "")
-      Add(sys_);
+  if (groupName_ == ""){
+    std::cout << "Warning::Adding sysetmatic with empty group name. Will apply to all events." << std::endl;
+    Add(sys_);
+  }
     fGroups[groupName_].push_back(sys_);
     fNGroups = fGroups.size();
 }

--- a/src/fitutil/SystematicManager.cpp
+++ b/src/fitutil/SystematicManager.cpp
@@ -56,7 +56,7 @@ SystematicManager::GetTotalResponse(const std::string &groupName_) const
 void SystematicManager::Add(Systematic *sys_, const std::string &groupName_)
 {
   if (groupName_ == ""){
-    std::cout << "Warning::Adding sysetmatic with empty group name. Will apply to all events." << std::endl;
+    std::cout << "Warning::Adding systematic with empty group name. Will apply to all events." << std::endl;
     Add(sys_);
   }
     fGroups[groupName_].push_back(sys_);

--- a/src/fitutil/SystematicManager.cpp
+++ b/src/fitutil/SystematicManager.cpp
@@ -56,7 +56,7 @@ SystematicManager::GetTotalResponse(const std::string &groupName_) const
 void SystematicManager::Add(Systematic *sys_, const std::string &groupName_)
 {
     if (groupName_ == "")
-        throw LogicError(Formatter() << "SystematicManager:: The group name \"\" is reserved and may not be used");
+      Add(sys_);
     fGroups[groupName_].push_back(sys_);
     fNGroups = fGroups.size();
 }


### PR DESCRIPTION
This is a minor thing, but currently if you have a systematic you want to apply too all groups, you have to add it to your BinnedNLLH without an argument for the groups. This means if you are looping over systematics, some with groups and some without, you have to do something like:

```
  for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it){
    if (systGroup[it->first] != "")
      lh.AddSystematic(it->second, systGroup[it->first]);
    else
      lh.AddSystematic(it->second);
  }
```

This PR would mean you no longer need the if statement so you can do something like:

```
 for (std::map<std::string, Systematic *>::iterator it = systMap.begin(); it != systMap.end(); ++it){
      lh.AddSystematic(it->second, systGroup[it->first]);
```

which is slightly tidier. 

The downside is a user could think they're adding a systematic with a group, so I output a warning. (Adding that warning makes me think we could have GetName be a method of Systematic, rather than each individual type (shape, shift etc.), so then in this warning we could tell the user which syst this is for, but let's save that for another day/pr)

Maybe there's other consequences I've not thought of though

 