### PR TITLE
Adding Ratio Constraints

### DIFF
--- a/src/constraint/ConstraintManager.cpp
+++ b/src/constraint/ConstraintManager.cpp
@@ -100,6 +100,14 @@ void ConstraintManager::SetConstraint(const std::string &paramName_1, double mea
     }
 }
 
+void ConstraintManager::SetConstraint(const std::string &paramName_1, const std::string &paramName_2, double ratiomean_, double ratiosigma_)
+{
+    /*
+     * Add/update a ratio constraint for a pair of parameters; we don't need to worry about other constraints
+     */
+    fConstraintsRatio[std::pair<std::string, std::string>(paramName_1, paramName_2)] = RatioConstraint(ratiomean_, ratiosigma_);
+}
+
 double ConstraintManager::Evaluate(const ParameterDict &params) const
 {
     /*
@@ -126,6 +134,18 @@ double ConstraintManager::Evaluate(const ParameterDict &params) const
         if (fDebugMode)
         {
             std::cout << "Pair constraint (" << param_pair.first << ", " << param_pair.second << "): Evaluate() = " << c << std::endl;
+        }
+    }
+
+    // ...and finally sum over the ratio constraints.
+    for (const auto &c_pair : fConstraintsRatio)
+    {
+        const std::pair<std::string, std::string> param_pair = c_pair.first;
+        const double c = c_pair.second.Evaluate(params.at(param_pair.first), params.at(param_pair.second));
+	total += c;
+        if (fDebugMode)
+        {
+            std::cout << "Ratio constraint (" << param_pair.first << ", " << param_pair.second << "): Evaluate() = " << c << std::endl;
         }
     }
 

--- a/src/constraint/ConstraintManager.h
+++ b/src/constraint/ConstraintManager.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <QuadraticConstraint.h>
 #include <BivariateQuadraticConstraint.h>
+#include <RatioConstraint.h>
 #include <ParameterDict.h>
 
 class ConstraintManager
@@ -23,6 +24,8 @@ public:
     // Add correlated constraint between two parameters
     void SetConstraint(const std::string &paramName_1, double mean_1, double sigma_1,
                        const std::string &paramName_2, double mean_2, double sigma_2, double correlation);
+    void SetConstraint(const std::string &paramName_1, const std::string &paramName_2,
+		       double ratiomean_, double ratiosigma_);
     // Evaluate sum of all constraints
     double Evaluate(const ParameterDict &params) const;
     //
@@ -35,6 +38,8 @@ private:
     std::map<std::pair<std::string, std::string>, BivariateQuadraticConstraint> fConstraintsPair;
     // Stores whether a given fit parameter has an individual (true) or pair (false) constraint
     std::map<std::string, bool> fUseIndConstraints;
+    // Stores ratio constraints between pairs of fit parameters
+    std::map<std::pair<std::string, std::string>, RatioConstraint> fConstraintsRatio;
     //
     bool fDebugMode;
 };

--- a/src/constraint/QuadraticConstraint.h
+++ b/src/constraint/QuadraticConstraint.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************/
 /* A quadratic constraint on a fit parameter, for log likelihood and Chi-Square tests this is  */
-/* equivlent to a gaussian contraint.                                                          */
+/* equivalent to a gaussian contraint.                                                         */
 /* If a second width is given, asymmetric errors are used.                                     */
 /***********************************************************************************************/
 #ifndef __OXSX_QUADRATIC_CONSTRAINT__

--- a/src/constraint/RatioConstraint.h
+++ b/src/constraint/RatioConstraint.h
@@ -1,0 +1,30 @@
+/***********************************************************************************************/
+/* A quadratic constraint on the ratio of two fit parameters.                                  */
+/* For log likelihood and Chi-Square tests this is equivalent to a gaussian contraint on the   */
+/* ratio.                                                                                      */
+/***********************************************************************************************/
+#ifndef __OXSX_RATIO_CONSTRAINT__
+#define __OXSX_RATIO_CONSTRAINT__
+#include <Exceptions.h>
+
+class RatioConstraint
+{
+public:
+    // Default constructor
+    RatioConstraint() {}
+    // Main constructor
+    RatioConstraint(double mean_, double sigma_ ) : fRatioMean(mean_), fRatioSigma(sigma_) { }
+
+    // Evaluate constraint at a particular pair of values
+    double Evaluate(double val_1, double val_2) const
+    {
+        const double ratio = val_1 / val_2;
+
+	return (ratio - fRatioMean) * (ratio - fRatioMean) / (2 * fRatioSigma * fRatioSigma);
+    }
+
+private:
+    double fRatioMean;
+    double fRatioSigma;
+};
+#endif

--- a/src/constraint/RatioConstraint.h
+++ b/src/constraint/RatioConstraint.h
@@ -18,6 +18,9 @@ public:
     // Evaluate constraint at a particular pair of values
     double Evaluate(double val_1, double val_2) const
     {
+      if(std::abs(val_2) < fEpsilon)
+          val_2 = fEpsilon;
+
         const double ratio = val_1 / val_2;
 
 	return (ratio - fRatioMean) * (ratio - fRatioMean) / (2 * fRatioSigma * fRatioSigma);
@@ -26,5 +29,6 @@ public:
 private:
     double fRatioMean;
     double fRatioSigma;
+    double fEpsilon = 1e-8;
 };
 #endif

--- a/test/unit/ConstraintsTest.cpp
+++ b/test/unit/ConstraintsTest.cpp
@@ -43,4 +43,10 @@ TEST_CASE("Constraints")
     {
         REQUIRE(c_man.Evaluate(params) == Catch::Approx(0.5 + 2. + (25. / 2. + 1. / 200. - 0.8 * 5 * (-1. / 10.)) / (1. - 0.8 * 0.8)));
     }
+    // Now add a ratio constraint
+    c_man.SetConstraint("c", "d", 5, 1);
+    SECTION("Ratio constraint Evaluation")
+    {
+        REQUIRE(c_man.Evaluate(params) == Catch::Approx(0.5 + 2. + (25. / 2. + 1. / 200. - 0.8 * 5 * (-1. / 10.)) / (1. - 0.8 * 0.8) + (25. / 2.) )  );
+    }
 }


### PR DESCRIPTION
In the antinu fit we leave the two geoneutrino fluxes free as they're poorly constrained by geological models, however, the models do have constraints on the relative contributions. So the other antinu analyses have a constraint on the ratio of the two fluxes. Initially I thought this could be handled equivalently with a correlated constraint, but I don't think that's possible if the individual normalisations are unconstrained.

So here I've added an extra constraint class to have a quadratic penalty on the ratio of two parameters. I don't think it matters whether or not the parameters have individual/correlated constraints as well

I've added it to the constraints unit test and it seems to be doing what it's supposed to