### PR TITLE
Allow Parameters to be Fixed in Metropolis Sampler

### DIFF
--- a/src/optimise/MetropolisSampler.cpp
+++ b/src/optimise/MetropolisSampler.cpp
@@ -12,12 +12,26 @@ void MetropolisSampler::SetSigmas(const ParameterDict &sig_)
     fSigmas = sig_;
 }
 
+void MetropolisSampler::Fix(const std::string &name_)
+{
+    fFixedParameters.insert(name_);
+}
+
+void MetropolisSampler::Release(const std::string &name_)
+{
+    fFixedParameters.erase(name_);
+}
+
 ParameterDict
 MetropolisSampler::Draw(const ParameterDict &current_)
 {
     ParameterDict newStep;
     for (ParameterDict::const_iterator it = current_.begin(); it != current_.end(); ++it)
     {
+      // If the parameter is fixed, don't change it
+      if( fFixedParameters.count(it->first) )
+	newStep[it->first] = it->second;
+      else
         newStep[it->first] = it->second + Rand::Gaus(0, fSigmas.at(it->first));
     }
     return newStep;

--- a/src/optimise/MetropolisSampler.h
+++ b/src/optimise/MetropolisSampler.h
@@ -2,6 +2,7 @@
 #define __OXSX_METROPOLIS_SAMPLER__
 #include <MCSampler.h>
 #include <ParameterDict.h>
+#include <set>
 
 class MetropolisSampler : public MCSampler
 {
@@ -9,10 +10,14 @@ public:
    const ParameterDict &GetSigmas() const;
    void SetSigmas(const ParameterDict &);
 
+   void Fix(const std::string &param_);
+   void Release(const std::string &param_);
+
    ParameterDict Draw(const ParameterDict &current_);
    inline double CorrectAccParam() { return 0; }
 
 private:
    ParameterDict fSigmas;
+   std::set<std::string> fFixedParameters;
 };
 #endif


### PR DESCRIPTION
With this PR, parameters can be fixed in the Metropolis Sampler, similarly to how they can be for the Minuit optimiser class. In theory, it might be nicer if this was done in the base Optimiser class, but it gets a bit more complicated (but not impossible!) with some using samplers and some not, especially for the Hamiltonian MCMC with the other classes it uses. So for now I think it's ok adding these in as and when we need them.

I haven't tested this fully yet (we should maybe add optimiser unit tests!), but opened this now so it can be looked at