### PR TITLE
Don't Re-Shrink PDFs 

### DIFF
--- a/src/fitutil/BinnedEDManager.cpp
+++ b/src/fitutil/BinnedEDManager.cpp
@@ -144,21 +144,31 @@ BinnedEDManager::ApplyShrink(const BinnedEDShrinker& shrinker_){
     for (size_t i = 0; i < fWorkingPdfs.size(); i++){
         // Normalise if normalisation is a fittable param, but if indirect then track any change
         if (fAllowNormsFittable.at(i) == DIRECT) {
-            fWorkingPdfs[i] = shrinker_.ShrinkDist(fWorkingPdfs.at(i));
-            fWorkingPdfs[i].Normalise();
+            if( fWorkingPdfs.at(0).GetNBins() == fOriginalPdfs.at(0).GetNBins() ){
+                fWorkingPdfs[i] = shrinker_.ShrinkDist(fWorkingPdfs.at(i));
+                fWorkingPdfs[i].Normalise();
+            }
+            else{
+                return;
+            }
         } else if (fAllowNormsFittable.at(i) == FALSE) {
-            fWorkingPdfs[i] = shrinker_.ShrinkDist(fWorkingPdfs.at(i));
-            const double integral_after = fWorkingPdfs[i].Integral();
-            fNormalisations[i] = integral_after;
-        } else {
-            const double integral_before = fWorkingPdfs[i].Integral();
-            fWorkingPdfs[i] = shrinker_.ShrinkDist(fWorkingPdfs.at(i));
-            const double integral_after = fWorkingPdfs[i].Integral();
-            if (integral_before == 0. && integral_after == 0.) { fNormalisations[i] = 0.; }
-            else { fNormalisations[i] *= integral_after/integral_before; }
-        }
+            if ( fWorkingPdfs.at(0).GetNBins() == fOriginalPdfs.at(0).GetNBins() ){
+                fWorkingPdfs[i] = shrinker_.ShrinkDist(fWorkingPdfs.at(i));
+                const double integral_after = fWorkingPdfs[i].Integral();
+                fNormalisations[i] = integral_after;
+            }
+            else{
+                return;
+            }
+      } else {
+    const double integral_before = fWorkingPdfs[i].Integral();
+    fWorkingPdfs[i] = shrinker_.ShrinkDist(fWorkingPdfs.at(i));
+    const double integral_after = fWorkingPdfs[i].Integral();
+    if (integral_before == 0. && integral_after == 0.) { fNormalisations[i] = 0.; }
+    else { fNormalisations[i] *= integral_after/integral_before; }
+      }
     }
-    
+
 }
 
 ////////////////////////////////


### PR DESCRIPTION
This PR modifies the logic in BinnedEDManager to not re-shrink a PDF if it's normalisation is not handled as INDIRECT. 
To illustrate the problem, I first committed an update to the unit tests. So if you checkout the first commit, the new test will fail. If you then checkout the second commit, the test (and all others) pass.

The issue manifested itself when you use a buffer, the shrunk pdf would be re-shrunk. On the second shrinking, the new PDF size is now `OriginalSize-2*buffer_region` (where `buffer_region` is sum of high and low buffers). So in the shrinking process, only that many bins get assigned values. Then when it comes to calculate the LLH for `OriginalSize-1*buffer_region` bins you get zero probability bins

The fix just uses the if statement from pre #25, but only for the Direct/False normalisation cases. There was a fixme comment before that if statement, saying have more obvious behaviour. But I think it's ok. Happy to hear suggestions though

Finally, the formatting is a bit off in BinnedEDManager.cpp. Somehow it looks like it evaded my previous formatting changes, so I'll fix that in another PR