### PR TITLE
Correctly use Systematic Groups in BinnedNLLH::AddPDFs

### DIFF
--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -215,11 +215,11 @@ void BinnedNLLH::AddPdfs(const std::vector<BinnedED> &pdfs,
     {
         if (norm_fitting_statuses != nullptr)
         {
-            AddPdf(pdfs.at(i), genrates_.at(i), norm_fitting_statuses->at(i));
+            AddPdf(pdfs.at(i), sys_.at(i), genrates_.at(i), norm_fitting_statuses->at(i));
         }
         else
         {
-            AddPdf(pdfs.at(i), genrates_.at(i));
+            AddPdf(pdfs.at(i), sys_.at(i), genrates_.at(i));
         }
     }
 }


### PR DESCRIPTION
Oof here's a bug and a half. In our BinnedNLLH teststat we have a few overloaded AddPDF and AddPDFs methods. When using AddPDFs, if you pass the systematic groups as an argument, it currently doesn't use the corresponding AddPDF with the syst groups as an argument.

Looks like I introduced it [here](https://github.com/snoplus/oxsx/commit/fb8265f165536f533b98aab19e4e01508f23876f#diff-b3e1de82bffd1909a5cca5a9fb918980b47cd97546802a4b66382b63ca58297e) and it made it through the great merge of 2022!