### PR TITLE
Avoid Adding Syst to Systman Groups Twice

### DIFF
--- a/src/fitutil/SystematicManager.cpp
+++ b/src/fitutil/SystematicManager.cpp
@@ -58,6 +58,7 @@ void SystematicManager::Add(Systematic *sys_, const std::string &groupName_)
   if (groupName_ == ""){
     std::cout << "Warning::Adding systematic with empty group name. Will apply to all events." << std::endl;
     Add(sys_);
+    return;
   }
     fGroups[groupName_].push_back(sys_);
     fNGroups = fGroups.size();


### PR DESCRIPTION
Fixes a bug I introduced in #51. We need to return out of SystematicManager::Add after using the alternative overloaded method, otherwise systematics get added to fGroups[""] twice and it rightfully complains

Ok this, #60, and #58 can all be reviewed and merged. When they're in and we have a fix for #55, then the review/merge of #59 will be more straightforward

@dcookman sorry for all the noise! We could have a call if it's easier to discuss the ordering, or just wait til Wednesday's OXO call