### PR TITLE
Fix for systematics in different groups

### DIFF
--- a/test/unit/BinnedNLLHTest.cpp
+++ b/test/unit/BinnedNLLHTest.cpp
@@ -4,6 +4,7 @@
 #include <Gaussian.h>
 #include <DistTools.h>
 #include <OXSXDataSet.h>
+#include <Shift.h>
 #include <iostream>
 
 TEST_CASE("Binned NLLH, 3 rates no systematics")
@@ -262,5 +263,957 @@ TEST_CASE("Binned NLLH, 3 rates no systematics")
     params["c"] = 1;
     lh2.SetParameters(params);
     REQUIRE_THAT(lh2.Evaluate(), Catch::Matchers::WithinAbs(sumNorm + sumLogProb + betaPen + constraint, 0.0001));
+  }
+}
+
+TEST_CASE("Binned NLLH, Grouping Systematics")
+{
+
+  SECTION("Two PDFs, two systematics in \"\" Group")
+  {
+
+    // Make BinnedEDs
+    AxisCollection ax;
+    // Two bins, each unit width
+    ax.AddAxis(BinAxis("xaxis", 0, 2, 2));
+    BinnedED pdf1("pdf1", ax);
+    BinnedED pdf2("pdf2", ax);
+    BinnedED data("data", ax);
+
+    // Some simple bin contents
+    double bin0_pdf1 = 4.;
+    double bin1_pdf1 = 6.;
+    double bin0_pdf2 = 3.;
+    double bin1_pdf2 = 2.;
+    double bin0_data = 3.;
+    double bin1_data = 4.;
+    pdf1.SetBinContent(0, bin0_pdf1);
+    pdf1.SetBinContent(1, bin1_pdf1);
+    pdf2.SetBinContent(0, bin0_pdf2);
+    pdf2.SetBinContent(1, bin1_pdf2);
+    data.SetBinContent(0, bin0_data);
+    data.SetBinContent(1, bin1_data);
+
+    // Now make 2 simple shift systematics
+    Shift *shift1 = new Shift("shift1");
+    shift1->RenameParameter("shift", "xshift1");
+    shift1->SetShift(0.0);
+    ObsSet obs = {"xaxis"};
+    shift1->SetAxes(ax);
+    shift1->SetTransformationObs(obs);
+    shift1->SetDistributionObs(obs);
+    shift1->Construct();
+
+    Shift *shift2 = new Shift("shift2");
+    shift2->RenameParameter("shift", "xshift2");
+    shift2->SetShift(0.0);
+    shift2->SetAxes(ax);
+    shift2->SetTransformationObs(obs);
+    shift2->SetDistributionObs(obs);
+    shift2->Construct();
+
+    // Make a LLH object
+    BinnedNLLH lh1;
+    lh1.SetDataDist(data);
+    lh1.AddSystematic(shift1, "");
+    lh1.AddSystematic(shift2, "");
+    std::vector<std::string> group1vec = {""};
+    std::vector<std::string> group2vec = {""};
+    lh1.AddPdf(pdf1, group1vec, 100);
+    lh1.AddPdf(pdf2, group2vec, 100);
+    lh1.RegisterFitComponents();
+
+    // And set some parameter values
+    double shiftval1 = 0.5;
+    double shiftval2 = 0.1;
+    double pdfnorm1 = 1.0;
+    double pdfnorm2 = 1.0;
+    ParameterDict parameterValues;
+    parameterValues["pdf1"] = pdfnorm1;
+    parameterValues["pdf2"] = pdfnorm2;
+    parameterValues["xshift1"] = shiftval1;
+    parameterValues["xshift2"] = shiftval2;
+
+    lh1.SetParameters(parameterValues);
+    double llh = lh1.Evaluate();
+
+    // Now let's calculate the llh by hand, applying the systematics ourselves
+    // Bin 0 loses events being shifted into Bin 1:
+    double bin0_pdf1_shift1 = bin0_pdf1 - shiftval1 * bin0_pdf1;
+    // Bin 1 loses events being shifted into the overflow, but gains from Bin 0:
+    double bin1_pdf1_shift1 = bin1_pdf1 + (shiftval1 * bin0_pdf1) - (shiftval1 * bin1_pdf1);
+    // And we can repeat for the second shift:
+    double bin0_pdf1_shift2 = bin0_pdf1_shift1 - shiftval2 * bin0_pdf1_shift1;
+    double bin1_pdf1_shift2 = bin1_pdf1_shift1 + (shiftval2 * bin0_pdf1_shift1) - (shiftval2 * bin1_pdf1_shift1);
+
+    // And we have the same for PDF 2:
+    double bin0_pdf2_shift1 = bin0_pdf2 - shiftval1 * bin0_pdf2;
+    double bin1_pdf2_shift1 = bin1_pdf2 + (shiftval1 * bin0_pdf2) - (shiftval1 * bin1_pdf2);
+    double bin0_pdf2_shift2 = bin0_pdf2_shift1 - shiftval2 * bin0_pdf2_shift1;
+    double bin1_pdf2_shift2 = bin1_pdf2_shift1 + (shiftval2 * bin0_pdf2_shift1) - (shiftval2 * bin1_pdf2_shift1);
+
+    // Now we can sum the total MC bin contents:
+    double bin0_totmc = (pdfnorm1 * bin0_pdf1_shift2) + (pdfnorm2 * bin0_pdf2_shift2);
+    double bin1_totmc = (pdfnorm1 * bin1_pdf1_shift2) + (pdfnorm2 * bin1_pdf2_shift2);
+
+    // And calculate the LLH! Summing -data*log(mc) + mc for each bin
+    double calcllh = (-bin0_data * log(bin0_totmc) + bin0_totmc) + (-bin1_data * log(bin1_totmc) + bin1_totmc);
+
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(calcllh, 0.0001));
+    // And compare to hand calculated value just to be sure:
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(-1.03259, 0.0001));
+  }
+
+  SECTION("Two PDFs, one systematic in \"\" Group, one in separate group")
+  {
+
+    // Make BinnedEDs
+    AxisCollection ax;
+    // Two bins, each unit width
+    ax.AddAxis(BinAxis("xaxis", 0, 2, 2));
+    BinnedED pdf1("pdf1", ax);
+    BinnedED pdf2("pdf2", ax);
+    BinnedED data("data", ax);
+
+    // Some simple bin contents
+    double bin0_pdf1 = 4.;
+    double bin1_pdf1 = 6.;
+    double bin0_pdf2 = 3.;
+    double bin1_pdf2 = 2.;
+    double bin0_data = 3.;
+    double bin1_data = 4.;
+    pdf1.SetBinContent(0, bin0_pdf1);
+    pdf1.SetBinContent(1, bin1_pdf1);
+    pdf2.SetBinContent(0, bin0_pdf2);
+    pdf2.SetBinContent(1, bin1_pdf2);
+    data.SetBinContent(0, bin0_data);
+    data.SetBinContent(1, bin1_data);
+
+    // Now make 2 simple shift systematics
+    Shift *shift1 = new Shift("shift1");
+    shift1->RenameParameter("shift", "xshift1");
+    shift1->SetShift(0.0);
+    ObsSet obs = {"xaxis"};
+    shift1->SetAxes(ax);
+    shift1->SetTransformationObs(obs);
+    shift1->SetDistributionObs(obs);
+    shift1->Construct();
+
+    Shift *shift2 = new Shift("shift2");
+    shift2->RenameParameter("shift", "xshift2");
+    shift2->SetShift(0.0);
+    shift2->SetAxes(ax);
+    shift2->SetTransformationObs(obs);
+    shift2->SetDistributionObs(obs);
+    shift2->Construct();
+
+    // Make a LLH object
+    BinnedNLLH lh1;
+    lh1.SetDataDist(data);
+    lh1.AddSystematic(shift1, "");
+    lh1.AddSystematic(shift2, "syst2");
+    std::vector<std::string> group1vec = {""};
+    std::vector<std::string> group2vec = {"syst2"};
+    lh1.AddPdf(pdf1, group1vec, 100);
+    lh1.AddPdf(pdf2, group2vec, 100);
+    lh1.RegisterFitComponents();
+
+    // And set some parameter values
+    double shiftval1 = 0.5;
+    double shiftval2 = 0.1;
+    double pdfnorm1 = 1.0;
+    double pdfnorm2 = 1.0;
+    ParameterDict parameterValues;
+    parameterValues["pdf1"] = pdfnorm1;
+    parameterValues["pdf2"] = pdfnorm2;
+    parameterValues["xshift1"] = shiftval1;
+    parameterValues["xshift2"] = shiftval2;
+
+    lh1.SetParameters(parameterValues);
+    double llh = lh1.Evaluate();
+
+    // Now let's calculate the llh by hand, applying the systematics ourselves
+    // Bin 0 loses events being shifted into Bin 1:
+    double bin0_pdf1_shift1 = bin0_pdf1 - shiftval1 * bin0_pdf1;
+    // Bin 1 loses events being shifted into the overflow, but gains from Bin 0:
+    double bin1_pdf1_shift1 = bin1_pdf1 + (shiftval1 * bin0_pdf1) - (shiftval1 * bin1_pdf1);
+    // But the second shift doesn''t apply to PDF 1
+
+    // And we have the same for PDF 2:
+    double bin0_pdf2_shift1 = bin0_pdf2 - shiftval1 * bin0_pdf2;
+    double bin1_pdf2_shift1 = bin1_pdf2 + (shiftval1 * bin0_pdf2) - (shiftval1 * bin1_pdf2);
+    double bin0_pdf2_shift2 = bin0_pdf2_shift1 - shiftval2 * bin0_pdf2_shift1;
+    double bin1_pdf2_shift2 = bin1_pdf2_shift1 + (shiftval2 * bin0_pdf2_shift1) - (shiftval2 * bin1_pdf2_shift1);
+
+    // Now we can sum the total MC bin contents:
+    double bin0_totmc = (pdfnorm1 * bin0_pdf1_shift1) + (pdfnorm2 * bin0_pdf2_shift2);
+    double bin1_totmc = (pdfnorm1 * bin1_pdf1_shift1) + (pdfnorm2 * bin1_pdf2_shift2);
+
+    // And calculate the LLH! Summing -data*log(mc) + mc for each bin
+    double calcllh = (-bin0_data * log(bin0_totmc) + bin0_totmc) + (-bin1_data * log(bin1_totmc) + bin1_totmc);
+
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(calcllh, 0.0001));
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(-0.88280, 0.0001));
+  }
+
+  SECTION("Two PDFs, two systematics in separate groups")
+  {
+
+    // Make BinnedEDs
+    AxisCollection ax;
+    // Two bins, each unit width
+    ax.AddAxis(BinAxis("xaxis", 0, 2, 2));
+    BinnedED pdf1("pdf1", ax);
+    BinnedED pdf2("pdf2", ax);
+    BinnedED data("data", ax);
+
+    // Some simple bin contents
+    double bin0_pdf1 = 4.;
+    double bin1_pdf1 = 6.;
+    double bin0_pdf2 = 3.;
+    double bin1_pdf2 = 2.;
+    double bin0_data = 3.;
+    double bin1_data = 4.;
+    pdf1.SetBinContent(0, bin0_pdf1);
+    pdf1.SetBinContent(1, bin1_pdf1);
+    pdf2.SetBinContent(0, bin0_pdf2);
+    pdf2.SetBinContent(1, bin1_pdf2);
+    data.SetBinContent(0, bin0_data);
+    data.SetBinContent(1, bin1_data);
+
+    // Now make 2 simple shift systematics
+    Shift *shift1 = new Shift("shift1");
+    shift1->RenameParameter("shift", "xshift1");
+    shift1->SetShift(0.0);
+    ObsSet obs = {"xaxis"};
+    shift1->SetAxes(ax);
+    shift1->SetTransformationObs(obs);
+    shift1->SetDistributionObs(obs);
+    shift1->Construct();
+
+    Shift *shift2 = new Shift("shift2");
+    shift2->RenameParameter("shift", "xshift2");
+    shift2->SetShift(0.0);
+    shift2->SetAxes(ax);
+    shift2->SetTransformationObs(obs);
+    shift2->SetDistributionObs(obs);
+    shift2->Construct();
+
+    // Make a LLH object
+    BinnedNLLH lh1;
+    lh1.SetDataDist(data);
+    lh1.AddSystematic(shift1, "syst1");
+    lh1.AddSystematic(shift2, "syst2");
+    std::vector<std::string> group1vec = {"syst1"};
+    std::vector<std::string> group2vec = {"syst2"};
+    lh1.AddPdf(pdf1, group1vec, 100);
+    lh1.AddPdf(pdf2, group2vec, 100);
+    lh1.RegisterFitComponents();
+
+    // And set some parameter values
+    double shiftval1 = 0.5;
+    double shiftval2 = 0.1;
+    double pdfnorm1 = 1.0;
+    double pdfnorm2 = 1.0;
+    ParameterDict parameterValues;
+    parameterValues["pdf1"] = pdfnorm1;
+    parameterValues["pdf2"] = pdfnorm2;
+    parameterValues["xshift1"] = shiftval1;
+    parameterValues["xshift2"] = shiftval2;
+
+    lh1.SetParameters(parameterValues);
+    double llh = lh1.Evaluate();
+
+    // Now let's calculate the llh by hand, applying the systematics ourselves
+    // Bin 0 loses events being shifted into Bin 1:
+    double bin0_pdf1_shift1 = bin0_pdf1 - shiftval1 * bin0_pdf1;
+    // Bin 1 loses events being shifted into the overflow, but gains from Bin 0:
+    double bin1_pdf1_shift1 = bin1_pdf1 + (shiftval1 * bin0_pdf1) - (shiftval1 * bin1_pdf1);
+    // But the second shift doesn''t apply to PDF 1
+
+    // And we have the same for PDF 2 and shift2:
+    double bin0_pdf2_shift2 = bin0_pdf2 - shiftval2 * bin0_pdf2;
+    double bin1_pdf2_shift2 = bin1_pdf2 + (shiftval2 * bin0_pdf2) - (shiftval2 * bin1_pdf2);
+
+    // Now we can sum the total MC bin contents:
+    double bin0_totmc = (pdfnorm1 * bin0_pdf1_shift1) + (pdfnorm2 * bin0_pdf2_shift2);
+    double bin1_totmc = (pdfnorm1 * bin1_pdf1_shift1) + (pdfnorm2 * bin1_pdf2_shift2);
+
+    // And calculate the LLH! Summing -data*log(mc) + mc for each bin
+    double calcllh = (-bin0_data * log(bin0_totmc) + bin0_totmc) + (-bin1_data * log(bin1_totmc) + bin1_totmc);
+
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(calcllh, 0.0001));
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(-0.68307, 0.0001));
+  }
+
+  SECTION("Two PDFs, one systematic in \"\" Group, one in separate group which contains both PDFs")
+  {
+
+    // Make BinnedEDs
+    AxisCollection ax;
+    // Two bins, each unit width
+    ax.AddAxis(BinAxis("xaxis", 0, 2, 2));
+    BinnedED pdf1("pdf1", ax);
+    BinnedED pdf2("pdf2", ax);
+    BinnedED data("data", ax);
+
+    // Some simple bin contents
+    double bin0_pdf1 = 4.;
+    double bin1_pdf1 = 6.;
+    double bin0_pdf2 = 3.;
+    double bin1_pdf2 = 2.;
+    double bin0_data = 3.;
+    double bin1_data = 4.;
+    pdf1.SetBinContent(0, bin0_pdf1);
+    pdf1.SetBinContent(1, bin1_pdf1);
+    pdf2.SetBinContent(0, bin0_pdf2);
+    pdf2.SetBinContent(1, bin1_pdf2);
+    data.SetBinContent(0, bin0_data);
+    data.SetBinContent(1, bin1_data);
+
+    // Now make 2 simple shift systematics
+    Shift *shift1 = new Shift("shift1");
+    shift1->RenameParameter("shift", "xshift1");
+    shift1->SetShift(0.0);
+    ObsSet obs = {"xaxis"};
+    shift1->SetAxes(ax);
+    shift1->SetTransformationObs(obs);
+    shift1->SetDistributionObs(obs);
+    shift1->Construct();
+
+    Shift *shift2 = new Shift("shift2");
+    shift2->RenameParameter("shift", "xshift2");
+    shift2->SetShift(0.0);
+    shift2->SetAxes(ax);
+    shift2->SetTransformationObs(obs);
+    shift2->SetDistributionObs(obs);
+    shift2->Construct();
+
+    // Make a LLH object
+    BinnedNLLH lh1;
+    lh1.SetDataDist(data);
+    lh1.AddSystematic(shift1, "");
+    lh1.AddSystematic(shift2, "syst2");
+    std::vector<std::string> group1vec = {"syst2"};
+    std::vector<std::string> group2vec = {"syst2"};
+    lh1.AddPdf(pdf1, group1vec, 100);
+    lh1.AddPdf(pdf2, group2vec, 100);
+    lh1.RegisterFitComponents();
+
+    // And set some parameter values
+    double shiftval1 = 0.5;
+    double shiftval2 = 0.1;
+    double pdfnorm1 = 1.0;
+    double pdfnorm2 = 1.0;
+    ParameterDict parameterValues;
+    parameterValues["pdf1"] = pdfnorm1;
+    parameterValues["pdf2"] = pdfnorm2;
+    parameterValues["xshift1"] = shiftval1;
+    parameterValues["xshift2"] = shiftval2;
+
+    lh1.SetParameters(parameterValues);
+    double llh = lh1.Evaluate();
+
+    // Now let's calculate the llh by hand, applying the systematics ourselves
+    // Bin 0 loses events being shifted into Bin 1:
+    double bin0_pdf1_shift1 = bin0_pdf1 - shiftval1 * bin0_pdf1;
+    // Bin 1 loses events being shifted into the overflow, but gains from Bin 0:
+    double bin1_pdf1_shift1 = bin1_pdf1 + (shiftval1 * bin0_pdf1) - (shiftval1 * bin1_pdf1);
+    // And we can repeat for the second shift:
+    double bin0_pdf1_shift2 = bin0_pdf1_shift1 - shiftval2 * bin0_pdf1_shift1;
+    double bin1_pdf1_shift2 = bin1_pdf1_shift1 + (shiftval2 * bin0_pdf1_shift1) - (shiftval2 * bin1_pdf1_shift1);
+
+    // And we have the same for PDF 2 and shift2:
+    double bin0_pdf2_shift1 = bin0_pdf2 - shiftval1 * bin0_pdf2;
+    double bin1_pdf2_shift1 = bin1_pdf2 + (shiftval1 * bin0_pdf2) - (shiftval1 * bin1_pdf2);
+    double bin0_pdf2_shift2 = bin0_pdf2_shift1 - shiftval2 * bin0_pdf2_shift1;
+    double bin1_pdf2_shift2 = bin1_pdf2_shift1 + (shiftval2 * bin0_pdf2_shift1) - (shiftval2 * bin1_pdf2_shift1);
+
+    // Now we can sum the total MC bin contents:
+    double bin0_totmc = (pdfnorm1 * bin0_pdf1_shift2) + (pdfnorm2 * bin0_pdf2_shift2);
+    double bin1_totmc = (pdfnorm1 * bin1_pdf1_shift2) + (pdfnorm2 * bin1_pdf2_shift2);
+
+    // And calculate the LLH! Summing -data*log(mc) + mc for each bin
+    double calcllh = (-bin0_data * log(bin0_totmc) + bin0_totmc) + (-bin1_data * log(bin1_totmc) + bin1_totmc);
+
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(calcllh, 0.0001));
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(-1.03259, 0.0001));
+  }
+
+  SECTION("Three PDFs, two systematics with separate groups")
+  {
+
+    // Make BinnedEDs
+    AxisCollection ax;
+    // Two bins, each unit width
+    ax.AddAxis(BinAxis("xaxis", 0, 2, 2));
+    BinnedED pdf1("pdf1", ax);
+    BinnedED pdf2("pdf2", ax);
+    BinnedED pdf3("pdf3", ax);
+    BinnedED data("data", ax);
+
+    // Some simple bin contents
+    double bin0_pdf1 = 4.;
+    double bin1_pdf1 = 6.;
+    double bin0_pdf2 = 3.;
+    double bin1_pdf2 = 2.;
+    double bin0_pdf3 = 2.;
+    double bin1_pdf3 = 4.;
+    double bin0_data = 3.;
+    double bin1_data = 4.;
+    pdf1.SetBinContent(0, bin0_pdf1);
+    pdf1.SetBinContent(1, bin1_pdf1);
+    pdf2.SetBinContent(0, bin0_pdf2);
+    pdf2.SetBinContent(1, bin1_pdf2);
+    pdf3.SetBinContent(0, bin0_pdf3);
+    pdf3.SetBinContent(1, bin1_pdf3);
+    data.SetBinContent(0, bin0_data);
+    data.SetBinContent(1, bin1_data);
+
+    // Now make 2 simple shift systematics
+    Shift *shift1 = new Shift("shift1");
+    shift1->RenameParameter("shift", "xshift1");
+    shift1->SetShift(0.0);
+    ObsSet obs = {"xaxis"};
+    shift1->SetAxes(ax);
+    shift1->SetTransformationObs(obs);
+    shift1->SetDistributionObs(obs);
+    shift1->Construct();
+
+    Shift *shift2 = new Shift("shift2");
+    shift2->RenameParameter("shift", "xshift2");
+    shift2->SetShift(0.0);
+    shift2->SetAxes(ax);
+    shift2->SetTransformationObs(obs);
+    shift2->SetDistributionObs(obs);
+    shift2->Construct();
+
+    // Make a LLH object
+    BinnedNLLH lh1;
+    lh1.SetDataDist(data);
+    lh1.AddSystematic(shift1, "syst1");
+    lh1.AddSystematic(shift2, "syst2");
+    std::vector<std::string> group1vec = {"syst1"};
+    std::vector<std::string> group2vec = {"syst2"};
+    std::vector<std::string> group3vec = {"syst2"};
+    lh1.AddPdf(pdf1, group1vec, 100);
+    lh1.AddPdf(pdf2, group2vec, 100);
+    lh1.AddPdf(pdf3, group3vec, 100);
+    lh1.RegisterFitComponents();
+
+    // And set some parameter values
+    double shiftval1 = 0.5;
+    double shiftval2 = 0.1;
+    double pdfnorm1 = 1.0;
+    double pdfnorm2 = 1.0;
+    double pdfnorm3 = 1.0;
+    ParameterDict parameterValues;
+    parameterValues["pdf1"] = pdfnorm1;
+    parameterValues["pdf2"] = pdfnorm2;
+    parameterValues["pdf3"] = pdfnorm3;
+    parameterValues["xshift1"] = shiftval1;
+    parameterValues["xshift2"] = shiftval2;
+
+    lh1.SetParameters(parameterValues);
+    double llh = lh1.Evaluate();
+
+    // Now let's calculate the llh by hand, applying the systematics ourselves
+    // Bin 0 loses events being shifted into Bin 1:
+    double bin0_pdf1_shift1 = bin0_pdf1 - shiftval1 * bin0_pdf1;
+    // Bin 1 loses events being shifted into the overflow, but gains from Bin 0:
+    double bin1_pdf1_shift1 = bin1_pdf1 + (shiftval1 * bin0_pdf1) - (shiftval1 * bin1_pdf1);
+    // But the second shift doesn't apply to PDF 1
+
+    // And we have shift2 for PDFs 2 and 3:
+    double bin0_pdf2_shift2 = bin0_pdf2 - shiftval2 * bin0_pdf2;
+    double bin1_pdf2_shift2 = bin1_pdf2 + (shiftval2 * bin0_pdf2) - (shiftval2 * bin1_pdf2);
+    double bin0_pdf3_shift2 = bin0_pdf3 - shiftval2 * bin0_pdf3;
+    double bin1_pdf3_shift2 = bin1_pdf3 + (shiftval2 * bin0_pdf3) - (shiftval2 * bin1_pdf3);
+
+    // Now we can sum the total MC bin contents:
+    double bin0_totmc = (pdfnorm1 * bin0_pdf1_shift1) + (pdfnorm2 * bin0_pdf2_shift2) + (pdfnorm3 * bin0_pdf3_shift2);
+    double bin1_totmc = (pdfnorm1 * bin1_pdf1_shift1) + (pdfnorm2 * bin1_pdf2_shift2) + (pdfnorm3 * bin1_pdf3_shift2);
+
+    // And calculate the LLH! Summing -data*log(mc) + mc for each bin
+    double calcllh = (-bin0_data * log(bin0_totmc) + bin0_totmc) + (-bin1_data * log(bin1_totmc) + bin1_totmc);
+
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(calcllh, 0.0001));
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(2.22954, 0.0001));
+  }
+
+  SECTION("Three PDFs, two systematics in different groups, one in \"\" group")
+  {
+
+    // Make BinnedEDs
+    AxisCollection ax;
+    // Two bins, each unit width
+    ax.AddAxis(BinAxis("xaxis", 0, 2, 2));
+    BinnedED pdf1("pdf1", ax);
+    BinnedED pdf2("pdf2", ax);
+    BinnedED pdf3("pdf3", ax);
+    BinnedED data("data", ax);
+
+    // Some simple bin contents
+    double bin0_pdf1 = 4.;
+    double bin1_pdf1 = 6.;
+    double bin0_pdf2 = 3.;
+    double bin1_pdf2 = 2.;
+    double bin0_pdf3 = 2.;
+    double bin1_pdf3 = 4.;
+    double bin0_data = 3.;
+    double bin1_data = 4.;
+    pdf1.SetBinContent(0, bin0_pdf1);
+    pdf1.SetBinContent(1, bin1_pdf1);
+    pdf2.SetBinContent(0, bin0_pdf2);
+    pdf2.SetBinContent(1, bin1_pdf2);
+    pdf3.SetBinContent(0, bin0_pdf3);
+    pdf3.SetBinContent(1, bin1_pdf3);
+    data.SetBinContent(0, bin0_data);
+    data.SetBinContent(1, bin1_data);
+
+    // Now make 2 simple shift systematics
+    Shift *shift1 = new Shift("shift1");
+    shift1->RenameParameter("shift", "xshift1");
+    shift1->SetShift(0.0);
+    ObsSet obs = {"xaxis"};
+    shift1->SetAxes(ax);
+    shift1->SetTransformationObs(obs);
+    shift1->SetDistributionObs(obs);
+    shift1->Construct();
+
+    Shift *shift2 = new Shift("shift2");
+    shift2->RenameParameter("shift", "xshift2");
+    shift2->SetShift(0.0);
+    shift2->SetAxes(ax);
+    shift2->SetTransformationObs(obs);
+    shift2->SetDistributionObs(obs);
+    shift2->Construct();
+
+    Shift *shift3 = new Shift("shift3");
+    shift3->RenameParameter("shift", "xshift3");
+    shift3->SetShift(0.0);
+    shift3->SetAxes(ax);
+    shift3->SetTransformationObs(obs);
+    shift3->SetDistributionObs(obs);
+    shift3->Construct();
+
+    // Make a LLH object
+    BinnedNLLH lh1;
+    lh1.SetDataDist(data);
+    lh1.AddSystematic(shift1, "");
+    lh1.AddSystematic(shift2, "syst2");
+    lh1.AddSystematic(shift3, "syst3");
+    std::vector<std::string> group1vec = {""};
+    std::vector<std::string> group2vec = {"syst2"};
+    std::vector<std::string> group3vec = {"syst3"};
+    lh1.AddPdf(pdf1, group1vec, 100);
+    lh1.AddPdf(pdf2, group2vec, 100);
+    lh1.AddPdf(pdf3, group3vec, 100);
+    lh1.RegisterFitComponents();
+
+    // And set some parameter values
+    double shiftval1 = 0.5;
+    double shiftval2 = 0.1;
+    double shiftval3 = -0.3;
+    double pdfnorm1 = 1.0;
+    double pdfnorm2 = 1.0;
+    double pdfnorm3 = 1.0;
+    ParameterDict parameterValues;
+    parameterValues["pdf1"] = pdfnorm1;
+    parameterValues["pdf2"] = pdfnorm2;
+    parameterValues["pdf3"] = pdfnorm3;
+    parameterValues["xshift1"] = shiftval1;
+    parameterValues["xshift2"] = shiftval2;
+    parameterValues["xshift3"] = shiftval3;
+
+    lh1.SetParameters(parameterValues);
+    double llh = lh1.Evaluate();
+
+    // Now let's calculate the llh by hand, applying the systematics ourselves
+    // Bin 0 loses events being shifted into Bin 1:
+    double bin0_pdf1_shift1 = bin0_pdf1 - shiftval1 * bin0_pdf1;
+    // Bin 1 loses events being shifted into the overflow, but gains from Bin 0:
+    double bin1_pdf1_shift1 = bin1_pdf1 + (shiftval1 * bin0_pdf1) - (shiftval1 * bin1_pdf1);
+    // But the second and third shifts don't apply to PDF 1
+
+    // And we have shift2 for PDF 2:
+    double bin0_pdf2_shift1 = bin0_pdf2 - shiftval1 * bin0_pdf2;
+    double bin1_pdf2_shift1 = bin1_pdf2 + (shiftval1 * bin0_pdf2) - (shiftval1 * bin1_pdf2);
+    double bin0_pdf2_shift2 = bin0_pdf2_shift1 - shiftval2 * bin0_pdf2_shift1;
+    double bin1_pdf2_shift2 = bin1_pdf2_shift1 + (shiftval2 * bin0_pdf2_shift1) - (shiftval2 * bin1_pdf2_shift1);
+
+    // And we have shift3 for PDFs 3:
+    double bin0_pdf3_shift1 = bin0_pdf3 - shiftval1 * bin0_pdf3;
+    double bin1_pdf3_shift1 = bin1_pdf3 + (shiftval1 * bin0_pdf3) - (shiftval1 * bin1_pdf3);
+    // As shift 3 has a negative value, the shift goes the other way
+    double bin0_pdf3_shift3 = bin0_pdf3_shift1 - (shiftval3 * bin1_pdf3_shift1) + (shiftval3 * bin0_pdf3_shift1);
+    double bin1_pdf3_shift3 = bin1_pdf3_shift1 + shiftval3 * bin1_pdf3_shift1;
+
+    // Now we can sum the total MC bin contents:
+    double bin0_totmc = (pdfnorm1 * bin0_pdf1_shift1) + (pdfnorm2 * bin0_pdf2_shift2) + (pdfnorm3 * bin0_pdf3_shift3);
+    double bin1_totmc = (pdfnorm1 * bin1_pdf1_shift1) + (pdfnorm2 * bin1_pdf2_shift2) + (pdfnorm3 * bin1_pdf3_shift3);
+
+    // And calculate the LLH! Summing -data*log(mc) + mc for each bin
+    double calcllh = (-bin0_data * log(bin0_totmc) + bin0_totmc) + (-bin1_data * log(bin1_totmc) + bin1_totmc);
+
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(calcllh, 0.0001));
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(0.64667, 0.0001));
+  }
+
+  SECTION("Three PDFs, two systematics in \"\" group, one in a separate group")
+  {
+
+    // Make BinnedEDs
+    AxisCollection ax;
+    // Two bins, each unit width
+    ax.AddAxis(BinAxis("xaxis", 0, 2, 2));
+    BinnedED pdf1("pdf1", ax);
+    BinnedED pdf2("pdf2", ax);
+    BinnedED pdf3("pdf3", ax);
+    BinnedED data("data", ax);
+
+    // Some simple bin contents
+    double bin0_pdf1 = 4.;
+    double bin1_pdf1 = 6.;
+    double bin0_pdf2 = 3.;
+    double bin1_pdf2 = 2.;
+    double bin0_pdf3 = 2.;
+    double bin1_pdf3 = 4.;
+    double bin0_data = 3.;
+    double bin1_data = 4.;
+    pdf1.SetBinContent(0, bin0_pdf1);
+    pdf1.SetBinContent(1, bin1_pdf1);
+    pdf2.SetBinContent(0, bin0_pdf2);
+    pdf2.SetBinContent(1, bin1_pdf2);
+    pdf3.SetBinContent(0, bin0_pdf3);
+    pdf3.SetBinContent(1, bin1_pdf3);
+    data.SetBinContent(0, bin0_data);
+    data.SetBinContent(1, bin1_data);
+
+    // Now make 2 simple shift systematics
+    Shift *shift1 = new Shift("shift1");
+    shift1->RenameParameter("shift", "xshift1");
+    shift1->SetShift(0.0);
+    ObsSet obs = {"xaxis"};
+    shift1->SetAxes(ax);
+    shift1->SetTransformationObs(obs);
+    shift1->SetDistributionObs(obs);
+    shift1->Construct();
+
+    Shift *shift2 = new Shift("shift2");
+    shift2->RenameParameter("shift", "xshift2");
+    shift2->SetShift(0.0);
+    shift2->SetAxes(ax);
+    shift2->SetTransformationObs(obs);
+    shift2->SetDistributionObs(obs);
+    shift2->Construct();
+
+    Shift *shift3 = new Shift("shift3");
+    shift3->RenameParameter("shift", "xshift3");
+    shift3->SetShift(0.0);
+    shift3->SetAxes(ax);
+    shift3->SetTransformationObs(obs);
+    shift3->SetDistributionObs(obs);
+    shift3->Construct();
+
+    // Make a LLH object
+    BinnedNLLH lh1;
+    lh1.SetDataDist(data);
+    lh1.AddSystematic(shift1, "");
+    lh1.AddSystematic(shift2, "");
+    lh1.AddSystematic(shift3, "syst3");
+    std::vector<std::string> group1vec = {""};
+    std::vector<std::string> group2vec = {""};
+    std::vector<std::string> group3vec = {"syst3"};
+    lh1.AddPdf(pdf1, group1vec, 100);
+    lh1.AddPdf(pdf2, group2vec, 100);
+    lh1.AddPdf(pdf3, group3vec, 100);
+    lh1.RegisterFitComponents();
+
+    // And set some parameter values
+    double shiftval1 = 0.5;
+    double shiftval2 = 0.1;
+    double shiftval3 = -0.3;
+    double pdfnorm1 = 1.0;
+    double pdfnorm2 = 1.0;
+    double pdfnorm3 = 1.0;
+    ParameterDict parameterValues;
+    parameterValues["pdf1"] = pdfnorm1;
+    parameterValues["pdf2"] = pdfnorm2;
+    parameterValues["pdf3"] = pdfnorm3;
+    parameterValues["xshift1"] = shiftval1;
+    parameterValues["xshift2"] = shiftval2;
+    parameterValues["xshift3"] = shiftval3;
+
+    lh1.SetParameters(parameterValues);
+    double llh = lh1.Evaluate();
+
+    // Now let's calculate the llh by hand, applying the systematics ourselves
+    // Bin 0 loses events being shifted into Bin 1:
+    double bin0_pdf1_shift1 = bin0_pdf1 - shiftval1 * bin0_pdf1;
+    // Bin 1 loses events being shifted into the overflow, but gains from Bin 0:
+    double bin1_pdf1_shift1 = bin1_pdf1 + (shiftval1 * bin0_pdf1) - (shiftval1 * bin1_pdf1);
+    // And do the same for shift 2:
+    double bin0_pdf1_shift2 = bin0_pdf1_shift1 - shiftval2 * bin0_pdf1_shift1;
+    double bin1_pdf1_shift2 = bin1_pdf1_shift1 + (shiftval2 * bin0_pdf1_shift1) - (shiftval2 * bin1_pdf1_shift1);
+
+    // And similarly for PDF 2:
+    double bin0_pdf2_shift1 = bin0_pdf2 - shiftval1 * bin0_pdf2;
+    double bin1_pdf2_shift1 = bin1_pdf2 + (shiftval1 * bin0_pdf2) - (shiftval1 * bin1_pdf2);
+    double bin0_pdf2_shift2 = bin0_pdf2_shift1 - shiftval2 * bin0_pdf2_shift1;
+    double bin1_pdf2_shift2 = bin1_pdf2_shift1 + (shiftval2 * bin0_pdf2_shift1) - (shiftval2 * bin1_pdf2_shift1);
+
+    // And we have shift3 for PDFs 3:
+    double bin0_pdf3_shift1 = bin0_pdf3 - shiftval1 * bin0_pdf3;
+    double bin1_pdf3_shift1 = bin1_pdf3 + (shiftval1 * bin0_pdf3) - (shiftval1 * bin1_pdf3);
+    double bin0_pdf3_shift2 = bin0_pdf3_shift1 - shiftval2 * bin0_pdf3_shift1;
+    double bin1_pdf3_shift2 = bin1_pdf3_shift1 + (shiftval2 * bin0_pdf3_shift1) - (shiftval2 * bin1_pdf3_shift1);
+    // As shift 3 has a negative value, the shift goes the other way
+    double bin0_pdf3_shift3 = bin0_pdf3_shift2 - (shiftval3 * bin1_pdf3_shift2) + (shiftval3 * bin0_pdf3_shift2);
+    double bin1_pdf3_shift3 = bin1_pdf3_shift2 + shiftval3 * bin1_pdf3_shift2;
+
+    // Now we can sum the total MC bin contents:
+    double bin0_totmc = (pdfnorm1 * bin0_pdf1_shift2) + (pdfnorm2 * bin0_pdf2_shift2) + (pdfnorm3 * bin0_pdf3_shift3);
+    double bin1_totmc = (pdfnorm1 * bin1_pdf1_shift2) + (pdfnorm2 * bin1_pdf2_shift2) + (pdfnorm3 * bin1_pdf3_shift3);
+
+    // And calculate the LLH! Summing -data*log(mc) + mc for each bin
+    double calcllh = (-bin0_data * log(bin0_totmc) + bin0_totmc) + (-bin1_data * log(bin1_totmc) + bin1_totmc);
+
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(calcllh, 0.0001));
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(0.27339, 0.0001));
+  }
+
+  SECTION("Three PDFs, three systematics all in separate groups")
+  {
+
+    // Make BinnedEDs
+    AxisCollection ax;
+    // Two bins, each unit width
+    ax.AddAxis(BinAxis("xaxis", 0, 2, 2));
+    BinnedED pdf1("pdf1", ax);
+    BinnedED pdf2("pdf2", ax);
+    BinnedED pdf3("pdf3", ax);
+    BinnedED data("data", ax);
+
+    // Some simple bin contents
+    double bin0_pdf1 = 4.;
+    double bin1_pdf1 = 6.;
+    double bin0_pdf2 = 3.;
+    double bin1_pdf2 = 2.;
+    double bin0_pdf3 = 2.;
+    double bin1_pdf3 = 4.;
+    double bin0_data = 3.;
+    double bin1_data = 4.;
+    pdf1.SetBinContent(0, bin0_pdf1);
+    pdf1.SetBinContent(1, bin1_pdf1);
+    pdf2.SetBinContent(0, bin0_pdf2);
+    pdf2.SetBinContent(1, bin1_pdf2);
+    pdf3.SetBinContent(0, bin0_pdf3);
+    pdf3.SetBinContent(1, bin1_pdf3);
+    data.SetBinContent(0, bin0_data);
+    data.SetBinContent(1, bin1_data);
+
+    // Now make 2 simple shift systematics
+    Shift *shift1 = new Shift("shift1");
+    shift1->RenameParameter("shift", "xshift1");
+    shift1->SetShift(0.0);
+    ObsSet obs = {"xaxis"};
+    shift1->SetAxes(ax);
+    shift1->SetTransformationObs(obs);
+    shift1->SetDistributionObs(obs);
+    shift1->Construct();
+
+    Shift *shift2 = new Shift("shift2");
+    shift2->RenameParameter("shift", "xshift2");
+    shift2->SetShift(0.0);
+    shift2->SetAxes(ax);
+    shift2->SetTransformationObs(obs);
+    shift2->SetDistributionObs(obs);
+    shift2->Construct();
+
+    Shift *shift3 = new Shift("shift3");
+    shift3->RenameParameter("shift", "xshift3");
+    shift3->SetShift(0.0);
+    shift3->SetAxes(ax);
+    shift3->SetTransformationObs(obs);
+    shift3->SetDistributionObs(obs);
+    shift3->Construct();
+
+    // Make a LLH object
+    BinnedNLLH lh1;
+    lh1.SetDataDist(data);
+    lh1.AddSystematic(shift1, "syst1");
+    lh1.AddSystematic(shift2, "syst2");
+    lh1.AddSystematic(shift3, "syst3");
+    std::vector<std::string> group1vec = {"syst1"};
+    std::vector<std::string> group2vec = {"syst2"};
+    std::vector<std::string> group3vec = {"syst3"};
+    lh1.AddPdf(pdf1, group1vec, 100);
+    lh1.AddPdf(pdf2, group2vec, 100);
+    lh1.AddPdf(pdf3, group3vec, 100);
+    lh1.RegisterFitComponents();
+
+    // And set some parameter values
+    double shiftval1 = 0.5;
+    double shiftval2 = 0.1;
+    double shiftval3 = -0.3;
+    double pdfnorm1 = 1.0;
+    double pdfnorm2 = 1.0;
+    double pdfnorm3 = 1.0;
+    ParameterDict parameterValues;
+    parameterValues["pdf1"] = pdfnorm1;
+    parameterValues["pdf2"] = pdfnorm2;
+    parameterValues["pdf3"] = pdfnorm3;
+    parameterValues["xshift1"] = shiftval1;
+    parameterValues["xshift2"] = shiftval2;
+    parameterValues["xshift3"] = shiftval3;
+
+    lh1.SetParameters(parameterValues);
+    double llh = lh1.Evaluate();
+
+    // Now let's calculate the llh by hand, applying the systematics ourselves
+    // Bin 0 loses events being shifted into Bin 1:
+    double bin0_pdf1_shift1 = bin0_pdf1 - shiftval1 * bin0_pdf1;
+    // Bin 1 loses events being shifted into the overflow, but gains from Bin 0:
+    double bin1_pdf1_shift1 = bin1_pdf1 + (shiftval1 * bin0_pdf1) - (shiftval1 * bin1_pdf1);
+
+    // And similarly for PDF 2:
+    double bin0_pdf2_shift2 = bin0_pdf2 - shiftval2 * bin0_pdf2;
+    double bin1_pdf2_shift2 = bin1_pdf2 + (shiftval2 * bin0_pdf2) - (shiftval2 * bin1_pdf2);
+
+    // And we have shift3 for PDFs 3:
+    double bin0_pdf3_shift3 = bin0_pdf3 - (shiftval3 * bin1_pdf3) + (shiftval3 * bin0_pdf3);
+    double bin1_pdf3_shift3 = bin1_pdf3 + shiftval3 * bin1_pdf3;
+
+    // Now we can sum the total MC bin contents:
+    double bin0_totmc = (pdfnorm1 * bin0_pdf1_shift1) + (pdfnorm2 * bin0_pdf2_shift2) + (pdfnorm3 * bin0_pdf3_shift3);
+    double bin1_totmc = (pdfnorm1 * bin1_pdf1_shift1) + (pdfnorm2 * bin1_pdf2_shift2) + (pdfnorm3 * bin1_pdf3_shift3);
+
+    // And calculate the LLH! Summing -data*log(mc) + mc for each bin
+    double calcllh = (-bin0_data * log(bin0_totmc) + bin0_totmc) + (-bin1_data * log(bin1_totmc) + bin1_totmc);
+
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(calcllh, 0.0001));
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(2.06624, 0.0001));
+  }
+
+  SECTION("Three PDFs, one systematic in the \"\" group, one applies to one PDF, one applies to two PDFs")
+  {
+
+    // Make BinnedEDs
+    AxisCollection ax;
+    // Two bins, each unit width
+    ax.AddAxis(BinAxis("xaxis", 0, 2, 2));
+    BinnedED pdf1("pdf1", ax);
+    BinnedED pdf2("pdf2", ax);
+    BinnedED pdf3("pdf3", ax);
+    BinnedED data("data", ax);
+
+    // Some simple bin contents
+    double bin0_pdf1 = 4.;
+    double bin1_pdf1 = 6.;
+    double bin0_pdf2 = 3.;
+    double bin1_pdf2 = 2.;
+    double bin0_pdf3 = 2.;
+    double bin1_pdf3 = 4.;
+    double bin0_data = 3.;
+    double bin1_data = 4.;
+    pdf1.SetBinContent(0, bin0_pdf1);
+    pdf1.SetBinContent(1, bin1_pdf1);
+    pdf2.SetBinContent(0, bin0_pdf2);
+    pdf2.SetBinContent(1, bin1_pdf2);
+    pdf3.SetBinContent(0, bin0_pdf3);
+    pdf3.SetBinContent(1, bin1_pdf3);
+    data.SetBinContent(0, bin0_data);
+    data.SetBinContent(1, bin1_data);
+
+    // Now make 2 simple shift systematics
+    Shift *shift1 = new Shift("shift1");
+    shift1->RenameParameter("shift", "xshift1");
+    shift1->SetShift(0.0);
+    ObsSet obs = {"xaxis"};
+    shift1->SetAxes(ax);
+    shift1->SetTransformationObs(obs);
+    shift1->SetDistributionObs(obs);
+    shift1->Construct();
+
+    Shift *shift2 = new Shift("shift2");
+    shift2->RenameParameter("shift", "xshift2");
+    shift2->SetShift(0.0);
+    shift2->SetAxes(ax);
+    shift2->SetTransformationObs(obs);
+    shift2->SetDistributionObs(obs);
+    shift2->Construct();
+
+    Shift *shift3 = new Shift("shift3");
+    shift3->RenameParameter("shift", "xshift3");
+    shift3->SetShift(0.0);
+    shift3->SetAxes(ax);
+    shift3->SetTransformationObs(obs);
+    shift3->SetDistributionObs(obs);
+    shift3->Construct();
+
+    // Make a LLH object
+    BinnedNLLH lh1;
+    lh1.SetDataDist(data);
+    lh1.AddSystematic(shift1, "");
+    lh1.AddSystematic(shift2, "syst2");
+    lh1.AddSystematic(shift3, "syst3");
+    std::vector<std::string> group1vec = {""};
+    std::vector<std::string> group2vec = {"syst2", "syst3"};
+    std::vector<std::string> group3vec = {"syst3"};
+    lh1.AddPdf(pdf1, group1vec, 100);
+    lh1.AddPdf(pdf2, group2vec, 100);
+    lh1.AddPdf(pdf3, group3vec, 100);
+    lh1.RegisterFitComponents();
+
+    // And set some parameter values
+    double shiftval1 = 0.5;
+    double shiftval2 = 0.1;
+    double shiftval3 = -0.3;
+    double pdfnorm1 = 1.0;
+    double pdfnorm2 = 1.0;
+    double pdfnorm3 = 1.0;
+    ParameterDict parameterValues;
+    parameterValues["pdf1"] = pdfnorm1;
+    parameterValues["pdf2"] = pdfnorm2;
+    parameterValues["pdf3"] = pdfnorm3;
+    parameterValues["xshift1"] = shiftval1;
+    parameterValues["xshift2"] = shiftval2;
+    parameterValues["xshift3"] = shiftval3;
+
+    lh1.SetParameters(parameterValues);
+    double llh = lh1.Evaluate();
+
+    // Now let's calculate the llh by hand, applying the systematics ourselves
+    // Bin 0 loses events being shifted into Bin 1:
+    double bin0_pdf1_shift1 = bin0_pdf1 - shiftval1 * bin0_pdf1;
+    // Bin 1 loses events being shifted into the overflow, but gains from Bin 0:
+    double bin1_pdf1_shift1 = bin1_pdf1 + (shiftval1 * bin0_pdf1) - (shiftval1 * bin1_pdf1);
+
+    // And shifts 1, 2 and 3 for PDF 2:
+    double bin0_pdf2_shift1 = bin0_pdf2 - shiftval1 * bin0_pdf2;
+    double bin1_pdf2_shift1 = bin1_pdf2 + (shiftval1 * bin0_pdf2) - (shiftval1 * bin1_pdf2);
+    double bin0_pdf2_shift2 = bin0_pdf2_shift1 - shiftval2 * bin0_pdf2_shift1;
+    double bin1_pdf2_shift2 = bin1_pdf2_shift1 + (shiftval2 * bin0_pdf2_shift1) - (shiftval2 * bin1_pdf2_shift1);
+    // As shift 3 has a negative value, the shift goes the other way
+    double bin0_pdf2_shift3 = bin0_pdf2_shift2 - (shiftval3 * bin1_pdf2_shift2) + (shiftval3 * bin0_pdf2_shift2);
+    double bin1_pdf2_shift3 = bin1_pdf2_shift2 + shiftval3 * bin1_pdf2_shift2;
+
+    // And we have shift 1 and 3 for PDFs 3:
+    double bin0_pdf3_shift1 = bin0_pdf3 - shiftval1 * bin0_pdf3;
+    double bin1_pdf3_shift1 = bin1_pdf3 + (shiftval1 * bin0_pdf3) - (shiftval1 * bin1_pdf3);
+    // As shift 3 has a negative value, the shift goes the other way
+    double bin0_pdf3_shift3 = bin0_pdf3_shift1 - (shiftval3 * bin1_pdf3_shift1) + (shiftval3 * bin0_pdf3_shift1);
+    double bin1_pdf3_shift3 = bin1_pdf3_shift1 + shiftval3 * bin1_pdf3_shift1;
+
+    // Now we can sum the total MC bin contents:
+    double bin0_totmc = (pdfnorm1 * bin0_pdf1_shift1) + (pdfnorm2 * bin0_pdf2_shift3) + (pdfnorm3 * bin0_pdf3_shift3);
+    double bin1_totmc = (pdfnorm1 * bin1_pdf1_shift1) + (pdfnorm2 * bin1_pdf2_shift3) + (pdfnorm3 * bin1_pdf3_shift3);
+
+    // And calculate the LLH! Summing -data*log(mc) + mc for each bin
+    double calcllh = (-bin0_data * log(bin0_totmc) + bin0_totmc) + (-bin1_data * log(bin1_totmc) + bin1_totmc);
+
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(calcllh, 0.0001));
+    REQUIRE_THAT(llh, Catch::Matchers::WithinAbs(0.371851, 0.0001));
   }
 }


### PR DESCRIPTION
This is the fix from #59, it also includes the tests from #62, but nothing else. So this and #62 can be reviewed and merged (if approved!)

(copying the text from #59):
So the big problem this fixes is for applying both at least one systematic in the global group, and at least one systematic in at least one other group. Firstly, previously, systematics were always applied to the OrignalEDs_, so when applying more than group to a PDF we'd do:

WorkingEDs_[j].SetBinContents(GetTotalResponse(groupName).operator()(OrignalEDs_.at(j).GetBinContents()));

then loop to the next groupName, and again do:

WorkingEDs_[j].SetBinContents(GetTotalResponse(groupName).operator()(OrignalEDs_.at(j).GetBinContents()));

So the last group is the only one that would be applied!

Also there was some funky logic with the global "" group. Previously if there were any systematics in the global group, these would get applied at the same time as applying any other group. So the global systematics could get applied more than once - if it weren't for the above bug meaning only last group's application would be used!

I've simplified (and hopefully corrected) the logic so we first apply the global group if there is anything in it, and then loop through groups applying them to the WorkingEDs_ so that each successive group is still used.



The main simplification comes from not treating the "" group differently really, just having it as one of the vector of the groups that can exist. With this the tests now pass ok


@dcookman thanks for reviewing and merging those previous pull requests! This and #62 can now be reviewed. That will leave the only unmerged component of #59 being the half-fix from #55. I'll leave #59 open for now as for the antinu analysis we need that "fix" so that gives us somewhere centralised we can work off (but if we did want to close it we could just work off the branch). And then the last thing will be getting a proper fix for #55. I remember we discussed it didn't work for all scenarios, but can't remember the details to be honest. But that will be something good to discuss at the first oxo call of the year!