### PR TITLE
Set default NormFittingStatus to INDIRECT

### DIFF
--- a/src/fitutil/BinnedEDManager.h
+++ b/src/fitutil/BinnedEDManager.h
@@ -24,7 +24,7 @@ class BinnedEDManager : public FitComponent
 public:
    BinnedEDManager() : fAllNormsDirFittable(true), fNPdfs(0), fName("norms") {}
 
-   void AddPdf(const BinnedED &, const NormFittingStatus norm_fitting_status = DIRECT);
+   void AddPdf(const BinnedED &, const NormFittingStatus norm_fitting_status = INDIRECT);
    void AddPdfs(const std::vector<BinnedED> &,
                 const std::vector<NormFittingStatus> *norm_fitting_statuses = nullptr);
 

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -47,10 +47,10 @@ public:
    void SetBuffer(const std::string &dim_, unsigned lower_, unsigned upper_);
    std::pair<unsigned, unsigned> GetBuffer(const std::string &dim_) const;
 
-   void AddPdf(const BinnedED &pdf, const NormFittingStatus norm_fitting_status = DIRECT);
-   void AddPdf(const BinnedED &pdf, const std::vector<std::string> &syss_, const NormFittingStatus norm_fitting_status = DIRECT);
-   void AddPdf(const BinnedED &pdf, const int &rate_, const NormFittingStatus norm_fitting_status = DIRECT);
-   void AddPdf(const BinnedED &pdf, const std::vector<std::string> &syss_, const int &rate_, const NormFittingStatus norm_fitting_status = DIRECT);
+   void AddPdf(const BinnedED &pdf, const NormFittingStatus norm_fitting_status = INDIRECT);
+   void AddPdf(const BinnedED &pdf, const std::vector<std::string> &syss_, const NormFittingStatus norm_fitting_status = INDIRECT);
+   void AddPdf(const BinnedED &pdf, const int &rate_, const NormFittingStatus norm_fitting_status = INDIRECT);
+   void AddPdf(const BinnedED &pdf, const std::vector<std::string> &syss_, const int &rate_, const NormFittingStatus norm_fitting_status = INDIRECT);
    void AddPdfs(const std::vector<BinnedED> &pdfs, const std::vector<NormFittingStatus> *norm_fitting_statuses = nullptr);
    void AddPdfs(const std::vector<BinnedED> &pdfs, const std::vector<std::vector<std::string>> &syss_, const std::vector<NormFittingStatus> *norm_fitting_statuses = nullptr);
    void AddPdfs(const std::vector<BinnedED> &pdfs, const std::vector<int> &rates_, const std::vector<NormFittingStatus> *norm_fitting_statuses = nullptr);


### PR DESCRIPTION
Doing "proper" analyses in OXO doesn't make much sense with the DIRECT method, unless you're not including systematics or shrinking. As a result, I've set the default `NormFittingStatus` for `BinnedED` objects to now be `INDIRECT`, which has the correct general behaviour when shrinking and systematics are applied. If you still want to use the (marginally faster) `DIRECT` mode, go ahead, but now at least you can't use the wrong mode accidentally.