### PR TITLE
DEF file for Container, and CMake build code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ config/userconfig.ini
 *.log
 bin/*.sh
 gsl/
+cmake-build-debug/
+*.sif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.16)
+project(
+    oxsx
+    VERSION 1.4.0
+    DESCRIPTION "The 'Oxford' Signal Extraction framework for the SNO+ experiment"
+    LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
+set(OXSX_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
+file(MAKE_DIRECTORY ${OXSX_INCLUDE_DIR})
+
+add_subdirectory(src)
+add_subdirectory(examples)
+add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,34 @@ Follow the installation instructions for each of the above using either the defa
 
 4. Test the build was sucessful with `./test/RunUnits`
 
+<h2> Alternative Installation Instructions Using Singularity/Apptainer & CMake </h2>
+OXSX now comes with the ability to compile the repository via the build system CMake, 
+and the definition file needed to create a container which will contain all of the necessary 
+external repositories.
+
+1. Clone this repository with `git clone https://github.com/snoplus/oxsx.git`
+
+2. Have either [Docker](https://www.docker.com/), [Singularity](https://sylabs.io/singularity/), or [Apptainer](https://apptainer.org/) installed on your system. These are programs which allow you to build Containers on your system.
+
+3. Navigate into the `oxsx` repository, and create an OXSX container `oxsx_container.sif` with the following command (this is for Apptainer; very similar commands for what follows are used for Docker/Singularity):
+```
+apptainer build oxsx_container.sif oxsx_container.def
+```
+
+4. Open the container:
+```
+apptainer shell oxsx_container.sif
+```
+
+5. Build the repository, using CMake:
+```
+cmake -S . -B cmake-build-debug
+cmake --build cmake-build-debug
+```
+This will create a new build directory, `cmake-build-debug`, as part of the build process. Feel free to use a different name, such as `build` - though that may clash with any existing `build` directory if you've also compiled OXSX with Sconscript. This build procedure generates the `oxsx` library, compiles all of the code in `example/` and builds all of the unit tests within `test/`.
+
+6. Test the build was successful with `./cmake-build-debug/test/unit/RunUnits`
+
 <h3> Compiling Your Own Scripts</h3>
 
 scons auto-generates a script that compiles and links your c++ against the source code and dependencies just run `. <oxsx root>/bin/compile.sh <your cpp file>` to produce an executible of the same name

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This will create a new build directory, `cmake-build-debug`, as part of the buil
 
 6. Test the build was successful with `./cmake-build-debug/test/unit/RunUnits`
 
-<h3> Compiling Your Own Scripts</h3>
+<h2> Compiling Your Own Scripts</h2>
 
 scons auto-generates a script that compiles and links your c++ against the source code and dependencies just run `. <oxsx root>/bin/compile.sh <your cpp file>` to produce an executible of the same name
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_subdirectory(data)
+add_subdirectory(pdf)
+add_subdirectory(plot)
+
+# Define where the example macro files are
+set(examples
+    beestonBarlowLHH.cpp
+    Cuts.cpp
+    DataSetGeneration.cpp
+    simpleFit.cpp
+    simpleSystematicFit.cpp
+    systematicFit.cpp
+    VaryingCDF.cpp
+)
+
+# Create an executable for each macro file
+foreach(macro_filename IN LISTS examples)
+    message("Macro filename: ${macro_filename}")
+    # By stripping macro's filepath, we can obtain string for executable name!
+    string(REPLACE ".cpp" "" macro ${macro_filename})
+    message("Macro executable name: ${macro}")
+    add_executable(${macro} ${macro_filename})
+    target_include_directories(${macro} PUBLIC ${OXSX_INCLUDE_DIR})
+    target_link_libraries(${macro} PUBLIC oxsx)
+endforeach()

--- a/examples/data/CMakeLists.txt
+++ b/examples/data/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Define where the example macro files are
+set(examples
+    ObsSet_example.cpp
+    ROOTNtuple.cpp
+)
+
+# Create an executable for each macro file
+foreach(macro_filename IN LISTS examples)
+    message("Macro filename: ${macro_filename}")
+    # By stripping macro's filepath, we can obtain string for executable name!
+    string(REPLACE ".cpp" "" macro ${macro_filename})
+    message("Macro executable name: ${macro}")
+    add_executable(${macro} ${macro_filename})
+    target_include_directories(${macro} PUBLIC ${OXSX_INCLUDE_DIR})
+    target_link_libraries(${macro} PUBLIC oxsx)
+endforeach()

--- a/examples/pdf/CMakeLists.txt
+++ b/examples/pdf/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Define where the example macro files are
+set(examples
+    AnalyticED_example.cpp
+    AnalyticToBinnedConversion.cpp
+    BinnedED_example.cpp
+    CompositeED_example.cpp
+    FillPdf.cpp
+)
+
+# Create an executable for each macro file
+foreach(macro_filename IN LISTS examples)
+    message("Macro filename: ${macro_filename}")
+    # By stripping macro's filepath, we can obtain string for executable name!
+    string(REPLACE ".cpp" "" macro ${macro_filename})
+    message("Macro executable name: ${macro}")
+    add_executable(${macro} ${macro_filename})
+    target_include_directories(${macro} PUBLIC ${OXSX_INCLUDE_DIR})
+    target_link_libraries(${macro} PUBLIC oxsx)
+endforeach()

--- a/examples/plot/CMakeLists.txt
+++ b/examples/plot/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Define where the example macro files are
+set(examples
+    ROOTOut.cpp
+)
+
+# Create an executable for each macro file
+foreach(macro_filename IN LISTS examples)
+    message("Macro filename: ${macro_filename}")
+    # By stripping macro's filepath, we can obtain string for executable name!
+    string(REPLACE ".cpp" "" macro ${macro_filename})
+    message("Macro executable name: ${macro}")
+    add_executable(${macro} ${macro_filename})
+    target_include_directories(${macro} PUBLIC ${OXSX_INCLUDE_DIR})
+    target_link_libraries(${macro} PUBLIC oxsx)
+endforeach()

--- a/oxsx_container.def
+++ b/oxsx_container.def
@@ -1,0 +1,12 @@
+Bootstrap: docker
+From: snoplus/rat-container:main
+
+
+%post
+	apt-get install -y libopenblas-dev libhdf5-cpp-103 libarmadillo9 libarmadillo-dev
+	
+	cd /home/software/
+	git clone https://github.com/catchorg/Catch2.git
+	cd Catch2/
+	cmake -B build -S . -DBUILD_TESTING=OFF
+	cmake --build build/ --target install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,76 @@
+#########################################################
+# CMake code to build the oxsx library
+#########################################################
+# Find relevant dependency packages
+find_package(ROOT CONFIG REQUIRED Minuit2) # ROOT
+find_package(Armadillo REQUIRED) # armadillo (for OXSX)
+find_package(HDF5 REQUIRED COMPONENTS CXX C) # HDF5 (for OXSX)
+find_package(GSL REQUIRED) # gsl (for OXSX)
+
+# Initialise a bunch of empty lists which we'll be using in a moment...
+set(oxsx_src_files "")
+set(config_src "")
+set(constraint_src "")
+set(core_src "")
+set(count_src "")
+set(cut_src "")
+set(data_src "")
+set(dist_src "")
+set(eventSystematic_src "")
+set(fitutil_src "")
+set(function_src "")
+set(histogram_src "")
+set(interval_src "")
+set(optimise_src "")
+set(plot_src "")
+set(rand_src "")
+set(systematic_src "")
+set(teststat_src "")
+
+# Do some work inside each subdirectory to copy the headers over to a central directory,
+# and define the src files present in that sub-drectory.
+add_subdirectory(config)
+add_subdirectory(constraint)
+add_subdirectory(core)
+add_subdirectory(count)
+add_subdirectory(cut)
+add_subdirectory(data)
+add_subdirectory(dist)
+add_subdirectory(eventSystematic)
+add_subdirectory(fitutil)
+add_subdirectory(function)
+add_subdirectory(histogram)
+add_subdirectory(interval)
+add_subdirectory(optimise)
+add_subdirectory(plot)
+add_subdirectory(rand)
+add_subdirectory(systematic)
+add_subdirectory(teststat)
+
+# Combine all of these source file lists into one!
+list(APPEND oxsx_src_files ${config_src} ${constraint_src} ${core_src} ${count_src} ${cut_src} ${data_src} ${dist_src} ${eventSystematic_src} ${fitutil_src} ${function_src} ${histogram_src} ${interval_src} ${optimise_src} ${plot_src} ${rand_src} ${systematic_src} ${teststat_src})
+
+# Create the oxsx library from the source files from all of the sub-directories!
+message("oxsx_src_files: ${oxsx_src_files}")
+message("OXSX_INCLUDE_DIR: ${OXSX_INCLUDE_DIR}")
+add_library(oxsx ${oxsx_src_files} ${OXSX_INCLUDE_DIR})
+target_include_directories(oxsx PUBLIC ${OXSX_INCLUDE_DIR})
+
+#---Link external dependencies: ----
+
+# ROOT
+target_include_directories(oxsx PUBLIC ${ROOT_INCLUDE_DIRS})
+target_link_libraries(oxsx PUBLIC ${ROOT_LIBRARIES})
+target_compile_options(oxsx PUBLIC "SHELL:${ROOT_DEFINITIONS}")
+
+# HDF5
+target_include_directories(oxsx PUBLIC ${HDF5_INCLUDE_DIRS})
+target_link_libraries(oxsx PUBLIC ${HDF5_CXX_LIBRARIES})
+
+# Armadillo (for OXSX)
+include_directories(${ARMADILLO_INCLUDE_DIRS})
+target_link_libraries(oxsx PUBLIC ${ARMADILLO_LIBRARIES})
+
+# GSL (for OXSX)
+include_directories(${GSL_INCLUDE_DIRS})
+target_link_libraries(oxsx PUBLIC ${GSL_LIBRARIES})

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(config_src
+    config/ConfigLoader.cpp
+    PARENT_SCOPE
+)
+
+set(config_headers
+    ConfigLoader.h
+    ConfigLoader.hh
+    ConfigLoader.hpp
+    ini.hpp
+)
+
+file(COPY ${config_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/constraint/CMakeLists.txt
+++ b/src/constraint/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(constraint_src
+    constraint/ConstraintManager.cpp
+    PARENT_SCOPE
+)
+
+set(constraint_headers
+    BivariateQuadraticConstraint.h
+    ConstraintManager.h
+    QuadraticConstraint.h
+    RatioConstraint.h
+)
+
+file(COPY ${constraint_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,31 @@
+set(core_src
+    core/Combinations.cpp
+    core/ComponentManager.cpp
+    core/ContainerTools.cpp
+    core/DenseMatrix.cpp
+    core/ParameterManager.cpp
+    core/SparseMatrix.cpp
+    PARENT_SCOPE
+)
+
+set(core_headers
+    Combinations.hpp
+    Comparison.hpp
+    ComponentManager.h
+    ContainerParameter.h
+    ContainerParameter.hpp
+    ContainerTools.hpp
+    DenseMatrix.h
+    DoubleParameter.h
+    Exceptions.h
+    FitComponent.h
+    FitParameter.h
+    Formatter.hpp
+    ParameterDict.h
+    ParameterManager.h
+    ParameterManager.hpp
+    SparseMatrix.h
+    TypeTraits.hpp
+)
+
+file(COPY ${core_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/core/DenseMatrix.h
+++ b/src/core/DenseMatrix.h
@@ -8,7 +8,6 @@
 
 #ifndef __OXSX_DENSE_MATRIX__
 #define __OXSX_DENSE_MATRIX__
-#include <AxisCollection.h>
 #include <armadillo>
 class BinnedPhysDist;
 

--- a/src/core/SparseMatrix.h
+++ b/src/core/SparseMatrix.h
@@ -8,7 +8,6 @@
 
 #ifndef __OXSX_SPARSE_MATRIX__
 #define __OXSX_SPARSE_MATRIX__
-#include <AxisCollection.h>
 #include <armadillo>
 class BinnedPhysDist;
 

--- a/src/count/CMakeLists.txt
+++ b/src/count/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(count_src
+    count/CountingExperiment.cpp
+    count/CountingResult.cpp
+    PARENT_SCOPE
+)
+
+set(count_headers
+    CountingExperiment.h
+    CountingResult.h
+)
+
+file(COPY ${count_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/cut/CMakeLists.txt
+++ b/src/cut/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(cut_src
+    cut/BoolCut.cpp
+    cut/BoxCut.cpp
+    cut/CutCollection.cpp
+    cut/CutLog.cpp
+    cut/LineCut.cpp
+    PARENT_SCOPE
+)
+
+set(cut_headers
+    BoolCut.h
+    BoxCut.h
+    Cut.h
+    CutCollection.h
+    CutLog.h
+    LineCut.h
+)
+
+file(COPY ${cut_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(data_src
+    data/DataSetGenerator.cpp
+    data/Event.cpp
+    data/IO.cpp
+    data/LazyOXSXDataSet.cpp
+    data/ObsSet.cpp
+    data/OXSXDataSet.cpp
+    data/ROOTNtuple.cpp
+    data/ROOTTree.cpp
+    PARENT_SCOPE
+)
+
+set(data_headers
+    DataSet.h
+    DataSetGenerator.h
+    Event.h
+    IO.h
+    LazyOXSXDataSet.h
+    ObsSet.h
+    ObsSet.hh
+    ROOTNtuple.h
+    ROOTTree.h
+)
+
+file(COPY ${data_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/dist/CMakeLists.txt
+++ b/src/dist/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(dist_src
+    dist/AnalyticED.cpp
+    dist/BinnedED.cpp
+    dist/BinnedEDGenerator.cpp
+    dist/CompositeED.cpp
+    dist/DistFiller.cpp
+    dist/DistTools.cpp
+    dist/SpectralFitDist.cpp
+    PARENT_SCOPE
+)
+
+set(dist_headers
+    AnalyticED.h
+    BinnedED.h
+    BinnedEDGenerator.h
+    CompositeED.h
+    DistFiller.h
+    DistTools.h
+    EventDistribution.h
+    SpectralFitDist.h
+)
+
+file(COPY ${dist_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/eventSystematic/CMakeLists.txt
+++ b/src/eventSystematic/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(eventSystematic_src
+    eventSystematic/EventConvolution.cpp
+    eventSystematic/EventReconvolution.cpp
+    eventSystematic/EventScale.cpp
+    eventSystematic/EventShift.cpp
+    eventSystematic/EventSystematic.cpp
+    PARENT_SCOPE
+)
+
+set(eventSystematic_headers
+    EventConvolution.h
+    EventReconvolution.h
+    EventScale.h
+    EventShift.h
+    EventSystematic.h
+)
+
+file(COPY ${eventSystematic_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/fitutil/CMakeLists.txt
+++ b/src/fitutil/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(fitutil_src
+    fitutil/BinnedEDManager.cpp
+    fitutil/BinnedEDShrinker.cpp
+    fitutil/EDManager.cpp
+    fitutil/EventSystematicManager.cpp
+    fitutil/SystematicManager.cpp
+    PARENT_SCOPE
+)
+
+set(fitutil_headers
+    BinnedEDManager.h
+    BinnedEDShrinker.h
+    EDManager.h
+    EventSystematicManager.h
+    SystematicManager.h
+)
+
+file(COPY ${fitutil_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/function/CMakeLists.txt
+++ b/src/function/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(function_src
+    function/Gaussian.cpp
+    function/GaussianFitter.cpp
+    function/Heaviside.cpp
+    function/JumpPDF.cpp
+    function/SquareRootScale.cpp
+    function/VaryingCDF.cpp
+    PARENT_SCOPE
+)
+
+set(function_headers
+    ConditionalPDF.h
+    Function.h
+    Gaussian.h
+    Gaussian.hpp
+    GaussianFitter.h
+    Heaviside.h
+    JumpPDF.h
+    PDF.h
+    SquareRootScale.h
+    VaryingCDF.h
+)
+
+file(COPY ${function_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/histogram/CMakeLists.txt
+++ b/src/histogram/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(histogram_src
+    histogram/AxisCollection.cpp
+    histogram/BinAxis.cpp
+    histogram/Histogram.cpp
+    histogram/HistTools.cpp
+    PARENT_SCOPE
+)
+
+set(histogram_headers
+    AxisCollection.h
+    BinAxis.h
+    Histogram.h
+    HistTools.h
+    HistTools.hpp
+)
+
+file(COPY ${histogram_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/interval/CMakeLists.txt
+++ b/src/interval/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(interval_src
+    interval/BayesIntervalCalc.cpp
+    PARENT_SCOPE
+)
+
+set(interval_headers
+    BayesIntervalCalc.h
+)
+
+file(COPY ${interval_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/optimise/CMakeLists.txt
+++ b/src/optimise/CMakeLists.txt
@@ -1,0 +1,37 @@
+set(optimise_src
+    optimise/AutoCorrelationCalc.cpp
+    optimise/FitResult.cpp
+    optimise/GridSearch.cpp
+    optimise/LeapFrog.cpp
+    optimise/MCMC.cpp
+    optimise/MCMCSamples.cpp
+    optimise/MetropolisSampler.cpp
+    optimise/Minuit.cpp
+    optimise/MinuitFCN.cpp
+    PARENT_SCOPE
+)
+
+set(optimise_headers
+    AutoCorrelationCalc.h
+    FitResult.h
+    Gradient.h
+    Gradient.hpp
+    GridSearch.h
+    HamiltonianSampler.h
+    HamiltonianSampler.hpp
+    HMCEnergy.h
+    HMCEnergy.hpp
+    LeapFrog.h
+    LeapFrog.hpp
+    MCMC.h
+    MCMCSamples.h
+    MCSampler.h
+    MetropolisSampler.h
+    Minuit.h
+    MinuitFCN.h
+    Optimiser.h
+    SigmoidBoundary.h
+    SigmoidBoundary.hpp
+)
+
+file(COPY ${optimise_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/plot/CMakeLists.txt
+++ b/src/plot/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(plot_src
+    plot/ROOTMultiPlot.cpp
+    PARENT_SCOPE
+)
+
+set(plot_headers
+    ROOTMultiPlot.h
+)
+
+file(COPY ${plot_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/rand/CMakeLists.txt
+++ b/src/rand/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(rand_src
+    rand/Rand.cpp
+    PARENT_SCOPE
+)
+
+set(rand_headers
+    Rand.h
+)
+
+file(COPY ${rand_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/systematic/CMakeLists.txt
+++ b/src/systematic/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(systematic_src
+    systematic/Convolution.cpp
+    systematic/Scale.cpp
+    systematic/ScaleFunction.cpp
+    systematic/Shape.cpp
+    systematic/Shift.cpp
+    systematic/Systematic.cpp
+    PARENT_SCOPE
+)
+
+set(systematic_headers
+    Convolution.h
+    Scale.h
+    ScaleFunction.h
+    Shape.h
+    Shift.h
+    Systematic.h
+)
+
+file(COPY ${systematic_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/src/teststat/CMakeLists.txt
+++ b/src/teststat/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(teststat_src
+    teststat/BinnedNLLH.cpp
+    teststat/ChiSquare.cpp
+    teststat/StatisticSum.cpp
+    PARENT_SCOPE
+)
+
+set(teststat_headers
+    BinnedNLLH.h
+    ChiSquare.h
+    StatisticSum.h
+    TestStatistic.h
+)
+
+file(COPY ${teststat_headers} DESTINATION ${OXSX_INCLUDE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(unit)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,0 +1,48 @@
+#
+find_package(Catch2 3 REQUIRED)
+
+# Define where the example macro files are
+set(tests
+    AxisCollectionTest.cpp
+    BinAxisTest.cpp
+    BinnedEDGeneratorTest.cpp
+    BinnedEDManagerTest.cpp
+    BinnedEDShrinkerTest.cpp
+    BinnedEDTest.cpp
+    BinnedNLLHTest.cpp
+    ComponentManagerTest.cpp
+    CompositeEDTest.cpp
+    ConstraintsTest.cpp
+    ConvolutionTest.cpp
+    CutTest.cpp
+    DataSetGeneratorTest.cpp
+    DataSetIOTest.cpp
+    DistToolsTest.cpp
+    EDManagerTest.cpp
+    EventScaleTest.cpp
+    EventShiftTest.cpp
+    EventSystematicManagerTest.cpp
+    FitParameterTest.cpp
+    GaussianFitterTest.cpp
+    GaussianTest.cpp
+    HistogramGetMultiDSlice.cpp
+    HistogramIOTest.cpp
+    HistToolsTest.cpp
+    ObservableSetTest.cpp
+    ParameterManagerTest.cpp
+    ScaleFuncSystTest.cpp
+    ScaleSystTest.cpp
+    ShapeTest.cpp
+    ShiftSystTest.cpp
+    SpectralFitDistTest.cpp
+    SquareRootScaleTest.cpp
+    StatisticSumTest.cpp
+    SystematicManagerTest.cpp
+    VaryingCDFTest.cpp
+)
+
+add_executable(RunUnits ${tests})
+target_include_directories(RunUnits PUBLIC ${OXSX_INCLUDE_DIR})
+target_link_libraries(RunUnits PUBLIC oxsx)
+
+target_link_libraries(RunUnits PRIVATE Catch2::Catch2WithMain)


### PR DESCRIPTION
This PR does two main things:

1. Create a file `oxsx_container.def`, which can be used to create a Container which holds all of the external dependencies necessary to run OXSX.
2. Add a bunch of CMake files, so that one can compile OXSX within the container.

Some instructions about how to run this has been added to the README.
I also removed a couple of redundant includes in some files, as a cleanup.