### PR TITLE
add OXSXDataSet.h to CMakeLists.txt

### DIFF
--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -18,6 +18,7 @@ set(data_headers
     LazyOXSXDataSet.h
     ObsSet.h
     ObsSet.hh
+    OXSXDataSet.h
     ROOTNtuple.h
     ROOTTree.h
 )


### PR DESCRIPTION
This is a (small) bug in the CMake build code that Manuel encountered.
I had missed the `OXSXDataSet.h` header in the relevant CMake build code, which caused compilation to crash for Manuel on the LIP remote machines.
Bafflingly, this oversight didn't cause a crash for me before, or Manuel on his laptop!
Either way, this should fix it.