### PR TITLE
Sparse matrix multiplication error

### DIFF
--- a/src/core/SparseMatrix.cpp
+++ b/src/core/SparseMatrix.cpp
@@ -57,12 +57,7 @@ SparseMatrix::operator()(const std::vector<double> &input_) const
     }
     catch (const std::logic_error &e_)
     {
-        throw DimensionError(Formatter() << "DenseMatrix::opeator() : Input v\
-ector ("
-                                         << input_.size() << ")"
-                                         << " wrong size for Matrix ("
-                                         << fNRows << "x" << fNCols
-                                         << " ) to act on");
+        throw DimensionError(Formatter() << "SparseMatrix::operator() : "<< e_.what());
     }
 
     // armadillo function for quick transfer to std::vector double
@@ -110,4 +105,5 @@ void SparseMatrix::SetComponents(const std::vector<long long unsigned int> &rowI
     locs.row(1) = arma::urowvec(colIndices_);
 
     fArmaMat = arma::sp_mat(locs, arma::vec(values_));
+    fArmaMat.resize(fNRows, fNCols); //Sets matrix back to its proper size incase it was shrunk
 }


### PR DESCRIPTION
Previous error message on line 60 of SpareMatrix outputted fNCols and fNRows as the matrix dimensions rather than the true current matrix dimensions. The new error will print the actual dimensions e.g 
terminate called after throwing an instance of 'DimensionError'
  what():  Failed to apply systematic :: SparseMatrix::operator() : matrix multiplication: incompatible matrix dimensions: 100x78 and 100x1

This line in SetComponent can shrink the matrix if an entire row/column doesn't have values set 
fArmaMat = arma::sp_mat(locs, arma::vec(values_));

Adding this line sets the matrix back to its original size
fArmaMat.resize(fNRows, fNCols);