### PR TITLE
Create basic OXO CI Workflow

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -24,12 +24,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Source ROOT (& RAT) environment
+      run: source entrypoint.sh
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: > 
-        source /usr/local/bin/entrypoint.sh
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -27,7 +27,9 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: > 
+        source entrypoint.sh
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -1,0 +1,41 @@
+# This starter workflow is for a CMake project running on a single platform. There is a different starter workflow if you need cross-platform coverage.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
+name: CMake on a single platform
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  REGISTRY: ghcr.io
+  # Use the repository name as the image name
+  IMAGE_NAME: ${{ github.repository }}
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ./${{github.workspace}}/build/test/unit/RunUnits
+

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -24,7 +24,7 @@ jobs:
       image: ghcr.io/snoplus/oxsx:1.4.0
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -24,7 +24,7 @@ jobs:
       packages: read # Grants the GITHUB_TOKEN read access to GHCR
     # Use the v1.4.0 OXSX container as a start point. That has what we need in it.
     container:
-      image: ghcr.io/snoplus/oxsx:1.4.0
+      image: ghcr.io/${{ github.repository }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -45,8 +45,5 @@ jobs:
       run: apptainer exec image.sif /bin/bash -c "source entrypoint.sh && cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: apptainer exec image.sif /bin/bash -c "source entrypoint.sh && ./${{github.workspace}}/build/test/unit/RunUnits"
 

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Source ROOT (& RAT) environment
-      run: ls /usr/local/bin/ && source /usr/local/bin/entrypoint.sh
+      run: ls / && ls /rat/ && source /usr/local/bin/entrypoint.sh
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -22,6 +22,9 @@ jobs:
     # Use the v1.4.0 OXSX container as a start point. That has what we need in it.
     container:
       image: ghcr.io/snoplus/oxsx:1.4.0
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Pull and Cache SIF
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | apptainer remote login -u ${{ github.actor }} --password-stdin oras://ghcr.io
-        apptainer pull image.sif oras://ghcr.io/${{ github.repository }}:latest
+        apptainer pull image.sif oras://ghcr.io/${{ github.repository }}:1.4.0
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Pull and Cache SIF
       run: |
-        apptainer remote login -u ${{ github.actor }} --password-stdin oras://ghcr.io
+        echo "${{ secrets.GITHUB_TOKEN }}" | apptainer remote login -u ${{ github.actor }} --password-stdin oras://ghcr.io
         apptainer pull image.sif oras://ghcr.io/${{ github.repository }}:latest
 
     - name: Configure CMake

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -7,9 +7,6 @@ on:
     branches: [ "master" ]
 
 env:
-  REGISTRY: ghcr.io
-  # Use the repository name as the image name
-  IMAGE_NAME: ${{ github.repository }}
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
@@ -22,32 +19,34 @@ jobs:
     permissions:
       contents: read
       packages: read # Grants the GITHUB_TOKEN read access to GHCR
-    # Use the v1.4.0 OXSX container as a start point. That has what we need in it.
-    container:
-      image: ghcr.io/${{ github.repository }}:1.4.0
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Source ROOT (& RAT) environment
-      run: source entrypoint.sh
+    - name: Install Apptainer
+      run: |
+        sudo add-apt-repository -y ppa:apptainer/ppa
+        sudo apt-get update
+        sudo apt-get install -y apptainer
+
+    - name: Pull and Cache SIF
+      run: |
+        apptainer remote login -u ${{ github.actor }} --password-stdin oras://ghcr.io
+        apptainer pull image.sif oras://ghcr.io/${{ github.repository }}:latest
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: apptainer exec image.sif /bin/bash -c "source entrypoint.sh && cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}"
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: apptainer exec image.sif /bin/bash -c "source entrypoint.sh && cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
 
     - name: Test
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ./${{github.workspace}}/build/test/unit/RunUnits
+      run: apptainer exec image.sif /bin/bash -c "source entrypoint.sh && ./${{github.workspace}}/build/test/unit/RunUnits"
 

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Source ROOT (& RAT) environment
-      run: source entrypoint.sh
+      run: ls /usr/local/bin/ && source /usr/local/bin/entrypoint.sh
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -24,7 +24,7 @@ jobs:
       image: ghcr.io/snoplus/oxsx:1.4.0
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.OXO_PAT }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -24,7 +24,7 @@ jobs:
       packages: read # Grants the GITHUB_TOKEN read access to GHCR
     # Use the v1.4.0 OXSX container as a start point. That has what we need in it.
     container:
-      image: ghcr.io/${{ github.repository }}
+      image: ghcr.io/${{ github.repository }}:1.4.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -45,5 +45,5 @@ jobs:
       run: apptainer exec image.sif /bin/bash -c "source entrypoint.sh && cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}"
 
     - name: Test
-      run: apptainer exec image.sif /bin/bash -c "source entrypoint.sh && ./${{github.workspace}}/build/test/unit/RunUnits"
+      run: apptainer exec image.sif /bin/bash -c "source entrypoint.sh && ${{github.workspace}}/build/test/unit/RunUnits"
 

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -19,12 +19,15 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read # Grants the GITHUB_TOKEN read access to GHCR
     # Use the v1.4.0 OXSX container as a start point. That has what we need in it.
     container:
       image: ghcr.io/snoplus/oxsx:1.4.0
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.OXO_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -19,13 +19,16 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-24.04
+    # Use the v1.4.0 OXSX container as a start point. That has what we need in it.
+    container:
+      image: ghcr.io/snoplus/oxsx:1.4.0
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
     - name: Source ROOT (& RAT) environment
-      run: ls / && ls /rat/ && source /usr/local/bin/entrypoint.sh
+      run: source entrypoint.sh
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -28,7 +28,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: > 
-        source entrypoint.sh
+        source /usr/local/bin/entrypoint.sh
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build


### PR DESCRIPTION
This is my first attempt at getting GitHub Actions CI workflow running.
It steals from the standard GitHub CMake project workflow, along with RAT's workflow.
Currently, we just use the OXO container, checkout the repo, build the repo, and then run the unit tests.
Frankly if we can get this to work I'll be really happy!
We can build on this further once we get this basic framework to behave. 