### PR TITLE
New GaussianConvolution & GaussianSqrtConvolution classes; Update to Scale systematic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ cmake-build-debug/
 cmake-build/
 *.sif
 cmake-build-forprof/
+cmake-build-valgrind/

--- a/examples/MCMC.cpp
+++ b/examples/MCMC.cpp
@@ -24,6 +24,7 @@ in these sorts of circumstances, which is valuable for us to know.
 #include <VaryingCDF.h>
 #include <SquareRootScale.h>
 #include <Convolution.h>
+#include <GaussianConvolution.h>
 // global consts
 constexpr double N_SIGNAL = 100.; // Truth signal rate in dataset
 constexpr double N_BACK = 300.; // Truth background rate in dataset
@@ -31,6 +32,7 @@ constexpr double SIGMA_BACK = 50.; // Constraint uncertainty on background norma
 constexpr double SIGMA_ESCALE = 0.01;
 constexpr double SIGMA_ESMEAR = 0.05;
 constexpr double SIGMA_RSCALE = 0.01;
+constexpr double SIGMA_RSMEAR = 0.02;
 constexpr size_t N_STEPS = 10000;
 const std::string outfilename_root = "mcmc_example_output.root";
 
@@ -118,6 +120,7 @@ void add_systematics(BinnedNLLH& lh_function) {
      *  - Energy scale
      *  - Energy smear
      *  - Radial scale
+     *  - Radial smear
      */
     // 1: Add energy scale
     Scale* escale = new Scale("energy_scale");
@@ -154,7 +157,7 @@ void add_systematics(BinnedNLLH& lh_function) {
     lh_function.AddSystematic(esmear);
     lh_function.SetConstraint("energy_smear_param", 0., SIGMA_ESMEAR);
 
-    // 3: Add radial smear
+    // 3: Add radial scale
     Scale* rscale = new Scale("radial_scale");
     rscale->RenameParameter("scaleFactor", "radial_scale_factor");
     rscale->SetScaleFactor(1.0);
@@ -165,6 +168,17 @@ void add_systematics(BinnedNLLH& lh_function) {
 
     lh_function.AddSystematic(rscale);
     lh_function.SetConstraint("radial_scale_factor", 1.0, SIGMA_RSCALE);
+
+    // 4: Add radial smear
+    GaussianConvolution* rsmear = new GaussianConvolution("radial_smear");
+    rsmear->RenameSigma("radial_smear_sigma");
+    rsmear->SetAxes(lh_function.GetDataDist().GetAxes());
+    rsmear->SetDistributionObs(ObsSet(std::vector<std::string>({"energy", "r3"})));
+    rsmear->SetTransformationObs(ObsSet("r3"));
+    rsmear->Construct();
+
+    lh_function.AddSystematic(rsmear);
+    lh_function.SetConstraint("radial_smear_sigma", 0., SIGMA_RSMEAR);
 }
 
 std::pair<double, double> calc_scale_bounds(BinnedNLLH& lh_function, 
@@ -222,6 +236,11 @@ void setup_metaparams(ParameterDict& minima, ParameterDict& maxima,
     maxima["radial_scale_factor"] = rscale_bounds.second;
     initial_vals["radial_scale_factor"] = 1.0;
     initial_err["radial_scale_factor"] = SIGMA_RSCALE;
+    // radial_smear_sigma
+    minima["radial_smear_sigma"] = 0.;
+    maxima["radial_smear_sigma"] = 5.*SIGMA_RSMEAR;
+    initial_vals["radial_smear_sigma"] = 0.00001;
+    initial_err["radial_smear_sigma"] = SIGMA_RSMEAR;
 }
 
 TTree* run_mcmc(BinnedNLLH& lh_function, const ParameterDict& minima, const ParameterDict& maxima,

--- a/examples/MCMC.cpp
+++ b/examples/MCMC.cpp
@@ -34,7 +34,7 @@ constexpr double SIGMA_ESCALE = 0.01;
 constexpr double SIGMA_ESMEAR = 0.05;
 constexpr double SIGMA_RSCALE = 0.01;
 constexpr double SIGMA_RSMEAR = 0.02;
-constexpr size_t N_STEPS = 100;
+constexpr size_t N_STEPS = 10000;
 const std::string outfilename_root = "mcmc_example_output.root";
 
 std::vector<BinnedED> load_mc(const AxisCollection& ax, const std::vector<std::string>& observables) {

--- a/examples/MCMC.cpp
+++ b/examples/MCMC.cpp
@@ -25,6 +25,7 @@ in these sorts of circumstances, which is valuable for us to know.
 #include <SquareRootScale.h>
 #include <Convolution.h>
 #include <GaussianConvolution.h>
+#include <GaussianSqrtConvolution.h>
 // global consts
 constexpr double N_SIGNAL = 100.; // Truth signal rate in dataset
 constexpr double N_BACK = 300.; // Truth background rate in dataset
@@ -33,7 +34,7 @@ constexpr double SIGMA_ESCALE = 0.01;
 constexpr double SIGMA_ESMEAR = 0.05;
 constexpr double SIGMA_RSCALE = 0.01;
 constexpr double SIGMA_RSMEAR = 0.02;
-constexpr size_t N_STEPS = 10000;
+constexpr size_t N_STEPS = 100;
 const std::string outfilename_root = "mcmc_example_output.root";
 
 std::vector<BinnedED> load_mc(const AxisCollection& ax, const std::vector<std::string>& observables) {
@@ -134,21 +135,24 @@ void add_systematics(BinnedNLLH& lh_function) {
     lh_function.AddSystematic(escale);
     lh_function.SetConstraint("energy_scale_factor", 1.0, SIGMA_ESCALE);
 
-    // 2: Add energy smear (a bit complicated!)
+    // 2: Add energy smear (less complicated than it used to be!)
     //   A Gaussian kernel...
-    VaryingCDF* smearer = new VaryingCDF("energy_smear");
-    Gaussian* gaus = new Gaussian(0, 0.01, "e_gaus"); // temp sigma value
-    gaus->RenameParameter("means_0", "mean");
-    gaus->RenameParameter("stddevs_0", "sigma");
-    smearer->SetKernel(gaus);
-    //   ...With a width scaling by the square root of the energy...
-    SquareRootScale* smear_sigma_func = new SquareRootScale("e_smear_sigma_func");
-    smear_sigma_func->RenameParameter("grad", "energy_smear_param");
-    smear_sigma_func->SetGradient(0.03); // temp gradient value
-    smearer->SetDependance("sigma", smear_sigma_func);
-    //  ...which smears the PDFs along the energy axis.
-    Convolution* esmear = new Convolution("esmear");
-    esmear->SetConditionalPDF(smearer);
+    // VaryingCDF* smearer = new VaryingCDF("energy_smear");
+    // Gaussian* gaus = new Gaussian(0, 0.01, "e_gaus"); // temp sigma value
+    // gaus->RenameParameter("means_0", "mean");
+    // gaus->RenameParameter("stddevs_0", "sigma");
+    // smearer->SetKernel(gaus);
+    // //   ...With a width scaling by the square root of the energy...
+    // SquareRootScale* smear_sigma_func = new SquareRootScale("e_smear_sigma_func");
+    // smear_sigma_func->RenameParameter("grad", "energy_smear_param");
+    // smear_sigma_func->SetGradient(0.03); // temp gradient value
+    // smearer->SetDependance("sigma", smear_sigma_func);
+    // //  ...which smears the PDFs along the energy axis.
+    // Convolution* esmear = new Convolution("esmear");
+    // esmear->SetConditionalPDF(smearer);
+
+    GaussianSqrtConvolution* esmear = new GaussianSqrtConvolution("esmear");
+    esmear->RenameSigma("energy_smear_param");
     esmear->SetAxes(lh_function.GetDataDist().GetAxes());
     esmear->SetDistributionObs(ObsSet(std::vector<std::string>({"energy", "r3"})));
     esmear->SetTransformationObs(ObsSet("energy"));

--- a/src/function/Gaussian.cpp
+++ b/src/function/Gaussian.cpp
@@ -36,7 +36,7 @@ Gaussian::Gaussian(const std::vector<double> &mean_,
     Initialise(mean_, stdDev_, name_);
 }
 
-Gaussian::Gaussian(const Gaussian &copy_) : fFitter(this, copy_.GetMeanNames(), copy_.GetStDevNames())
+Gaussian::Gaussian(const Gaussian &copy_) : fFitter(this, copy_.GetMeanNames(), copy_.GetStDevNames(), copy_.GetHideMeanParameters())
 {
     fMeans = copy_.fMeans;
     fStdDevs = copy_.fStdDevs;
@@ -53,7 +53,7 @@ Gaussian::operator=(const Gaussian &copy_)
     fCdfCutOff = copy_.fCdfCutOff;
     fNDims = copy_.fNDims;
     fName = std::string(copy_.fName + "_copy");
-    fFitter = GaussianFitter(this, copy_.GetMeanNames(), copy_.GetStDevNames());
+    fFitter = GaussianFitter(this, copy_.GetMeanNames(), copy_.GetStDevNames(), copy_.GetHideMeanParameters());
     return *this;
 }
 
@@ -169,6 +169,16 @@ size_t
 Gaussian::GetNDims() const
 {
     return fNDims;
+}
+
+void Gaussian::HideMeanParameters()
+{
+    fFitter.HideMeanParameters();
+}
+
+bool Gaussian::GetHideMeanParameters() const
+{
+    return fFitter.GetHideMeanParameters();
 }
 
 /////////////////

--- a/src/function/Gaussian.h
+++ b/src/function/Gaussian.h
@@ -42,6 +42,9 @@ public:
    void SetCdfCutOff(double);
    size_t GetNDims() const;
 
+   void HideMeanParameters();
+   bool GetHideMeanParameters() const;
+
    // Make this object fittable
    void SetParameter(const std::string &name_, double value);
    double GetParameter(const std::string &name_) const;

--- a/src/function/GaussianFitter.cpp
+++ b/src/function/GaussianFitter.cpp
@@ -10,7 +10,7 @@
 
 using ContainerTools::ToString;
 
-GaussianFitter::GaussianFitter(Gaussian *gaus, const size_t &nDims_)
+GaussianFitter::GaussianFitter(Gaussian *gaus, const size_t &nDims_) : fHideMeans(false)
 {
     fOrignalFunc = gaus;
     std::stringstream ss;
@@ -25,7 +25,7 @@ GaussianFitter::GaussianFitter(Gaussian *gaus, const size_t &nDims_)
     }
 }
 
-GaussianFitter::GaussianFitter(Gaussian *gaus, const std::vector<std::string> &meanNames_, const std::vector<std::string> &stdDevNames_)
+GaussianFitter::GaussianFitter(Gaussian *gaus, const std::vector<std::string> &meanNames_, const std::vector<std::string> &stdDevNames_, bool hideMeans_) : fHideMeans(hideMeans_)
 {
     if (meanNames_.size() != stdDevNames_.size())
         throw OXSXException(Formatter() << "GaussianFitter:: #meanName != #stdDevNames");
@@ -43,11 +43,14 @@ void GaussianFitter::RenameParameter(const std::string &old_, const std::string 
     if (find(fMeansNames.begin(), fMeansNames.end(), old_) == fMeansNames.end() && find(fStdDevsNames.begin(), fStdDevsNames.end(), old_) == fStdDevsNames.end())
         throw NotFoundError(Formatter() << "GaussianFitter:: When attempting to renaming the parameter " << old_ << ", it wasn't found. Available names: " << ToString(GetParameterNames()));
 
-    it = find(fMeansNames.begin(), fMeansNames.end(), old_);
-    while (it != fMeansNames.end())
+    if (!fHideMeans)
     {
-        *it = new_;
-        it = find(it++, fMeansNames.end(), old_);
+        it = find(fMeansNames.begin(), fMeansNames.end(), old_);
+        while (it != fMeansNames.end())
+        {
+            *it = new_;
+            it = find(it++, fMeansNames.end(), old_);
+        }
     }
 
     it = find(fStdDevsNames.begin(), fStdDevsNames.end(), old_);
@@ -73,11 +76,14 @@ GaussianFitter::GetStdDevNames() const
 void GaussianFitter::SetParameter(const std::string &name_, double value_)
 {
     std::vector<std::string>::iterator it;
-    it = find(fMeansNames.begin(), fMeansNames.end(), name_);
-    while (it != fMeansNames.end())
+    if (!fHideMeans)
     {
-        fOrignalFunc->SetMean(it - fMeansNames.begin(), value_);
-        it = find(++it, fMeansNames.end(), name_);
+        it = find(fMeansNames.begin(), fMeansNames.end(), name_);
+        while (it != fMeansNames.end())
+        {
+            fOrignalFunc->SetMean(it - fMeansNames.begin(), value_);
+            it = find(++it, fMeansNames.end(), name_);
+        }
     }
     it = find(fStdDevsNames.begin(), fStdDevsNames.end(), name_);
     while (it != fStdDevsNames.end())
@@ -96,7 +102,7 @@ GaussianFitter::GetParameter(const std::string &name_) const
 
     std::vector<std::string>::const_iterator it;
     it = find(fMeansNames.begin(), fMeansNames.end(), name_);
-    if (it == fMeansNames.end())
+    if (fHideMeans || it == fMeansNames.end())
     {
         it = find(fStdDevsNames.begin(), fStdDevsNames.end(), name_);
         if (it == fStdDevsNames.end())
@@ -122,12 +128,12 @@ GaussianFitter::GetParameters() const
     std::vector<double> values;
 
     values.reserve(means.size() + stddevs.size()); // preallocate memory
-    values.insert(values.end(), means.begin(), means.end());
+    if (!fHideMeans) { values.insert(values.end(), means.begin(), means.end()); }
     values.insert(values.end(), stddevs.begin(), stddevs.end());
 
     std::vector<std::string> names;
     names.reserve(fMeansNames.size() + fStdDevsNames.size()); // preallocate memory
-    names.insert(names.end(), fMeansNames.begin(), fMeansNames.end());
+    if (!fHideMeans) { names.insert(names.end(), fMeansNames.begin(), fMeansNames.end()); }
     names.insert(names.end(), fStdDevsNames.begin(), fStdDevsNames.end());
 
     return ContainerTools::CreateMap(names, values);
@@ -136,7 +142,7 @@ GaussianFitter::GetParameters() const
 size_t
 GaussianFitter::GetParameterCount() const
 {
-    return fMeansNames.size() + fStdDevsNames.size();
+    return fHideMeans ? fStdDevsNames.size() : fMeansNames.size() + fStdDevsNames.size();
 }
 
 std::set<std::string>
@@ -145,7 +151,7 @@ GaussianFitter::GetParameterNames() const
     std::set<std::string> names;
     for (size_t i = 0; i < fMeansNames.size(); ++i)
     {
-        names.insert(fMeansNames.at(i));
+        if (!fHideMeans) { names.insert(fMeansNames.at(i)); }
         names.insert(fStdDevsNames.at(i));
     }
     return names;

--- a/src/function/GaussianFitter.h
+++ b/src/function/GaussianFitter.h
@@ -12,7 +12,7 @@ class GaussianFitter
 {
 public:
     GaussianFitter(Gaussian *gaus, const size_t &nDims);
-    GaussianFitter(Gaussian *gaus, const std::vector<std::string> &, const std::vector<std::string> &);
+    GaussianFitter(Gaussian *gaus, const std::vector<std::string> &, const std::vector<std::string> &, bool hideMeans_);
 
     void SetParameter(const std::string &name_, double value);
     double GetParameter(const std::string &name_) const;
@@ -27,9 +27,16 @@ public:
     std::vector<std::string> GetMeanNames() const;
     std::vector<std::string> GetStdDevNames() const;
 
+    // Option to hide the means from being observed as a parameter
+    // (Useful when we want to use the Gaussian as a kernel, and only
+    // want the fit to be able to modify the sigmas and not the means)
+    void HideMeanParameters() { fHideMeans = true; }
+    bool GetHideMeanParameters() const { return fHideMeans; }
+
 private:
     Gaussian *fOrignalFunc;
     std::vector<std::string> fMeansNames;
     std::vector<std::string> fStdDevsNames;
+    bool fHideMeans;
 };
 #endif

--- a/src/systematic/CMakeLists.txt
+++ b/src/systematic/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(systematic_src
     systematic/Convolution.cpp
     systematic/GaussianConvolution.cpp
+    systematic/GaussianSqrtConvolution.cpp
     systematic/Renorm.cpp
     systematic/Scale.cpp
     systematic/ScaleFunction.cpp
@@ -13,6 +14,7 @@ set(systematic_src
 set(systematic_headers
     Convolution.h
     GaussianConvolution.h
+    GaussianSqrtConvolution.h
     Renorm.h
     Scale.h
     ScaleFunction.h

--- a/src/systematic/CMakeLists.txt
+++ b/src/systematic/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(systematic_src
     systematic/Convolution.cpp
+    systematic/GaussianConvolution.cpp
     systematic/Renorm.cpp
     systematic/Scale.cpp
     systematic/ScaleFunction.cpp
@@ -11,6 +12,7 @@ set(systematic_src
 
 set(systematic_headers
     Convolution.h
+    GaussianConvolution.h
     Renorm.h
     Scale.h
     ScaleFunction.h

--- a/src/systematic/Convolution.cpp
+++ b/src/systematic/Convolution.cpp
@@ -40,119 +40,25 @@ void Convolution::ConstructSubmatrix(std::vector<long long unsigned int> &column
     column_indices.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
     row_indices.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
     vals.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
-    // In case of smearing over 1 dimension only, we can get clever and do things a lot faster!
-    if (fSubMapAxes.GetNDimensions() == 1)
+    
+    // Loop over all entries of the sub-matrix to determine their values
+    for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
     {
-        // Some tricks we are pulling here to make things go even faster:
-        // - In most use cases, the binning along the smearing axis is ~equal,
-        //   so the amount of smearing will become translation-invariant!
-        //   Cache calculations of the smearing Integral() (which is expensive)
-        //   in a map object based on the integration endpoints (the output bin edges)
-        //   After the first row, we expect ~all integrals to have already been calculated!
-        // - For typical smearing kernels, the contribution necessarily goes monotonically down
-        //   for bins further away from the original bin. In other words, we expect this submatrix
-        //   to be quite diagonal-heavy, with no random spikes far away.
-        //   Also, beyond some distance we expect the contribution to go to zero.
-        //   Instead of blithely scanning as usual over the full 2D grid of (origBin, destBin),
-        //   we now start ~along the diagonal and work outwards - first forwards, then backwards.
-        //   Whenever a zero is reached, we immediately exit the loop! 
-        std::map<std::pair<double, double>, double> integral_cache;
-        // Loop over all entries of the sub-matrix to determine their values
-        for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
+        // get the centre of the bin. Need to offset by this for a convolution
+        fSubMapAxes.GetBinCentres(origBin, binCentres);
+
+        // loop over the bins it can be smeared into
+        for (long long unsigned int destBin = 0; destBin < fSubMapAxes.GetNBins(); destBin++)
         {
-            // get the centre of the bin. Need to offset by this for a convolution
-            fSubMapAxes.GetBinCentres(origBin, binCentres);
-
-            // loop over the bins it can be smeared into, going forwards
-            // from the bin after the diagonal first 
-            for (long long unsigned int destBin = origBin+1; destBin < fSubMapAxes.GetNBins(); destBin++)
+            fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
+            fSubMapAxes.GetBinHighEdges(destBin, highEdges);
+            const double integral = fDist->Integral(lowEdges, highEdges, binCentres);
+            // only bother adding to matrix if non-zero!
+            if (integral > 0.)
             {
-                fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
-                fSubMapAxes.GetBinHighEdges(destBin, highEdges);
-
-                // Calculate destination bin edges along smearing axis, relative
-                // to origBin's centre
-                const double xlo = lowEdges.at(0) - binCentres.at(0);
-                const double xhi = lowEdges.at(0) - binCentres.at(0);
-                const std::pair<double, double> edges {xlo, xhi};
-                // Has an integral already been calculated for this pair of (relative) bin edges?
-                const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
-                double integral = 0.;
-                if (it == integral_cache.end())
-                {
-                    // Nope, need to calculate the integral (and add it to the cache)
-                    integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                    integral_cache[edges] = integral;
-                } else
-                {
-                    // Yep, use that result!
-                    integral = it->second;
-                }
-
-                // Only bother adding to matrix if non-zero!
-                // No point looking at any further destination bins in this loop
-                // as we know they'll be zero too
-                if (integral == 0.)
-                {
-                    break;
-                }
                 column_indices.push_back(origBin);
                 row_indices.push_back(destBin);
                 vals.push_back(integral);
-            }
-            // Now do the same inner loop, but going backwards, starting from
-            // the diagonal - this ensures we don't accidentally try negative bins initially
-            for (long long unsigned int destBin = origBin; destBin < fSubMapAxes.GetNBins(); destBin--)
-            {
-                fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
-                fSubMapAxes.GetBinHighEdges(destBin, highEdges);
-
-                const double xlo = lowEdges.at(0) - binCentres.at(0);
-                const double xhi = lowEdges.at(0) - binCentres.at(0);
-                const std::pair<double, double> edges {xlo, xhi};
-                const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
-                double integral = 0.;
-                if (it == integral_cache.end())
-                {
-                    integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                    integral_cache[edges] = integral;
-                } else
-                {
-                    integral = it->second;
-                }
-
-                if (integral == 0.)
-                {
-                    break;
-                }
-                column_indices.push_back(origBin);
-                row_indices.push_back(destBin);
-                vals.push_back(integral);
-            }
-        }
-    } else
-    {
-        // You're trying to use a 2D kernel?? Weird, but okay: we'll just try
-        // the old-fashioned way for now.
-        // Loop over all entries of the sub-matrix to determine their values
-        for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
-        {
-            // get the centre of the bin. Need to offset by this for a convolution
-            fSubMapAxes.GetBinCentres(origBin, binCentres);
-
-            // loop over the bins it can be smeared into
-            for (long long unsigned int destBin = 0; destBin < fSubMapAxes.GetNBins(); destBin++)
-            {
-                fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
-                fSubMapAxes.GetBinHighEdges(destBin, highEdges);
-                const double integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                // only bother adding to matrix if non-zero!
-                if (integral > 0.)
-                {
-                    column_indices.push_back(origBin);
-                    row_indices.push_back(destBin);
-                    vals.push_back(integral);
-                }
             }
         }
     }

--- a/src/systematic/Convolution.cpp
+++ b/src/systematic/Convolution.cpp
@@ -40,24 +40,119 @@ void Convolution::ConstructSubmatrix(std::vector<long long unsigned int> &column
     column_indices.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
     row_indices.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
     vals.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
-    // Loop over all entries of the sub-matrix to determine their values
-    for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
+    // In case of smearing over 1 dimension only, we can get clever and do things a lot faster!
+    if (fSubMapAxes.GetNDimensions() == 1)
     {
-        // get the centre of the bin. Need to offset by this for a convolution
-        fSubMapAxes.GetBinCentres(origBin, binCentres);
-
-        // loop over the bins it can be smeared into
-        for (long long unsigned int destBin = 0; destBin < fSubMapAxes.GetNBins(); destBin++)
+        // Some tricks we are pulling here to make things go even faster:
+        // - In most use cases, the binning along the smearing axis is ~equal,
+        //   so the amount of smearing will become translation-invariant!
+        //   Cache calculations of the smearing Integral() (which is expensive)
+        //   in a map object based on the integration endpoints (the output bin edges)
+        //   After the first row, we expect ~all integrals to have already been calculated!
+        // - For typical smearing kernels, the contribution necessarily goes monotonically down
+        //   for bins further away from the original bin. In other words, we expect this submatrix
+        //   to be quite diagonal-heavy, with no random spikes far away.
+        //   Also, beyond some distance we expect the contribution to go to zero.
+        //   Instead of blithely scanning as usual over the full 2D grid of (origBin, destBin),
+        //   we now start ~along the diagonal and work outwards - first forwards, then backwards.
+        //   Whenever a zero is reached, we immediately exit the loop! 
+        std::map<std::pair<double, double>, double> integral_cache;
+        // Loop over all entries of the sub-matrix to determine their values
+        for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
         {
-            fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
-            fSubMapAxes.GetBinHighEdges(destBin, highEdges);
-            const double integral = fDist->Integral(lowEdges, highEdges, binCentres);
-            // only bother adding to matrix if non-zero!
-            if (integral > 0.)
+            // get the centre of the bin. Need to offset by this for a convolution
+            fSubMapAxes.GetBinCentres(origBin, binCentres);
+
+            // loop over the bins it can be smeared into, going forwards
+            // from the bin after the diagonal first 
+            for (long long unsigned int destBin = origBin+1; destBin < fSubMapAxes.GetNBins(); destBin++)
             {
+                fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
+                fSubMapAxes.GetBinHighEdges(destBin, highEdges);
+
+                // Calculate destination bin edges along smearing axis, relative
+                // to origBin's centre
+                const double xlo = lowEdges.at(0) - binCentres.at(0);
+                const double xhi = lowEdges.at(0) - binCentres.at(0);
+                const std::pair<double, double> edges {xlo, xhi};
+                // Has an integral already been calculated for this pair of (relative) bin edges?
+                const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
+                double integral = 0.;
+                if (it == integral_cache.end())
+                {
+                    // Nope, need to calculate the integral (and add it to the cache)
+                    integral = fDist->Integral(lowEdges, highEdges, binCentres);
+                    integral_cache[edges] = integral;
+                } else
+                {
+                    // Yep, use that result!
+                    integral = it->second;
+                }
+
+                // Only bother adding to matrix if non-zero!
+                // No point looking at any further destination bins in this loop
+                // as we know they'll be zero too
+                if (integral == 0.)
+                {
+                    break;
+                }
                 column_indices.push_back(origBin);
                 row_indices.push_back(destBin);
                 vals.push_back(integral);
+            }
+            // Now do the same inner loop, but going backwards, starting from
+            // the diagonal - this ensures we don't accidentally try negative bins initially
+            for (long long unsigned int destBin = origBin; destBin < fSubMapAxes.GetNBins(); destBin--)
+            {
+                fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
+                fSubMapAxes.GetBinHighEdges(destBin, highEdges);
+
+                const double xlo = lowEdges.at(0) - binCentres.at(0);
+                const double xhi = lowEdges.at(0) - binCentres.at(0);
+                const std::pair<double, double> edges {xlo, xhi};
+                const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
+                double integral = 0.;
+                if (it == integral_cache.end())
+                {
+                    integral = fDist->Integral(lowEdges, highEdges, binCentres);
+                    integral_cache[edges] = integral;
+                } else
+                {
+                    integral = it->second;
+                }
+
+                if (integral == 0.)
+                {
+                    break;
+                }
+                column_indices.push_back(origBin);
+                row_indices.push_back(destBin);
+                vals.push_back(integral);
+            }
+        }
+    } else
+    {
+        // You're trying to use a 2D kernel?? Weird, but okay: we'll just try
+        // the old-fashioned way for now.
+        // Loop over all entries of the sub-matrix to determine their values
+        for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
+        {
+            // get the centre of the bin. Need to offset by this for a convolution
+            fSubMapAxes.GetBinCentres(origBin, binCentres);
+
+            // loop over the bins it can be smeared into
+            for (long long unsigned int destBin = 0; destBin < fSubMapAxes.GetNBins(); destBin++)
+            {
+                fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
+                fSubMapAxes.GetBinHighEdges(destBin, highEdges);
+                const double integral = fDist->Integral(lowEdges, highEdges, binCentres);
+                // only bother adding to matrix if non-zero!
+                if (integral > 0.)
+                {
+                    column_indices.push_back(origBin);
+                    row_indices.push_back(destBin);
+                    vals.push_back(integral);
+                }
             }
         }
     }
@@ -103,7 +198,7 @@ void Convolution::MakeFullMatrix(const std::vector<long long unsigned int> &colu
 void Convolution::Construct()
 {
     /*
-     * Method that constructs the response matrix associated with this convlution systematic.
+     * Method that constructs the response matrix associated with this convolution systematic.
      * Attempts to be clever and speedy about building this, because this method can get computationally-
      * expensive, fast, when dealing with BinnedED objects with numerous dimensions and many bins!
      *

--- a/src/systematic/Convolution.h
+++ b/src/systematic/Convolution.h
@@ -39,7 +39,7 @@ public:
    std::string GetName() const;
    void SetName(const std::string &);
 
-private:
+protected:
    ConditionalPDF *fDist; // kernel used in convolution
    std::string fName;     // name of this object
    // Members needed for efficient calculations:

--- a/src/systematic/Convolution.h
+++ b/src/systematic/Convolution.h
@@ -51,7 +51,7 @@ protected:
    AxisCollection DetermineAxisSubCollection(const std::vector<size_t> &rel_indices) const;
    size_t BlockedBinningIndex(size_t bin_index, const std::vector<size_t> &relativeIndices) const;
    void CacheIndexPermutations();
-   void ConstructSubmatrix(std::vector<long long unsigned int> &column_indices, std::vector<long long unsigned int> &row_indices,
+   virtual void ConstructSubmatrix(std::vector<long long unsigned int> &column_indices, std::vector<long long unsigned int> &row_indices,
                            std::vector<double> &vals) const;
    void MakeFullMatrix(const std::vector<long long unsigned int> &column_indices, const std::vector<long long unsigned int> &row_indices,
                        const std::vector<double> &vals, SparseMatrix &response_blocked) const;

--- a/src/systematic/GaussianConvolution.cpp
+++ b/src/systematic/GaussianConvolution.cpp
@@ -48,7 +48,10 @@ void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int>
     // - In most use cases, the binning along the smearing axis is ~equal,
     //   so the amount of smearing will become translation-invariant!
     //   Cache calculations of the smearing Integral() (which is expensive)
-    //   in a map object based on the integration endpoints (the output bin edges)
+    //   in a map object based on the integration upper endpoint (the output upper bin edge).
+    //   We're always calculating the integral relative to the bin centre,
+    //   so the upper and lower endpoints will be symmetric. We can therefore index
+    //   simply by the upper (relative) endpoint, say.
     //   After the first row, we expect ~all integrals to have already been calculated!
     // - For typical smearing kernels, the contribution necessarily goes monotonically down
     //   for bins further away from the original bin. In other words, we expect this submatrix
@@ -57,7 +60,7 @@ void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int>
     //   Instead of blithely scanning as usual over the full 2D grid of (origBin, destBin),
     //   we now start ~along the diagonal and work outwards - first forwards, then backwards.
     //   Whenever a zero is reached, we immediately exit the loop! 
-    std::map<std::pair<double, double>, double> integral_cache;
+    std::map<double, double> integral_cache;
     // Loop over all entries of the sub-matrix to determine their values
     for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
     {
@@ -71,19 +74,17 @@ void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int>
             fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
             fSubMapAxes.GetBinHighEdges(destBin, highEdges);
 
-            // Calculate destination bin edges along smearing axis, relative
+            // Calculate destination upper bin edge along smearing axis, relative
             // to origBin's centre
-            const double xlo = lowEdges.at(0) - binCentres.at(0);
-            const double xhi = lowEdges.at(0) - binCentres.at(0);
-            const std::pair<double, double> edges {xlo, xhi};
-            // Has an integral already been calculated for this pair of (relative) bin edges?
-            const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
+            const double xhi = highEdges.at(0) - binCentres.at(0);
+            // Has an integral already been calculated for this relative bin edge?
+            const auto it = integral_cache.find(xhi);
             double integral = 0.;
             if (it == integral_cache.end())
             {
                 // Nope, need to calculate the integral (and add it to the cache)
                 integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                integral_cache[edges] = integral;
+                integral_cache[xhi] = integral;
             } else
             {
                 // Yep, use that result!
@@ -108,15 +109,13 @@ void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int>
             fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
             fSubMapAxes.GetBinHighEdges(destBin, highEdges);
 
-            const double xlo = lowEdges.at(0) - binCentres.at(0);
             const double xhi = lowEdges.at(0) - binCentres.at(0);
-            const std::pair<double, double> edges {xlo, xhi};
-            const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
+            const auto it = integral_cache.find(xhi);
             double integral = 0.;
             if (it == integral_cache.end())
             {
                 integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                integral_cache[edges] = integral;
+                integral_cache[xhi] = integral;
             } else
             {
                 integral = it->second;

--- a/src/systematic/GaussianConvolution.cpp
+++ b/src/systematic/GaussianConvolution.cpp
@@ -1,0 +1,153 @@
+#include <GaussianConvolution.h>
+#include <JumpPDF.h>
+#include <ConditionalPDF.h>
+#include <Gaussian.h>
+
+GaussianConvolution::GaussianConvolution(const std::string &name_) :
+Convolution(name_), sigma_name("stddevs_0")
+{
+    // Set the kernel to be a Gaussian.
+    // SetFunction() clones this Gaussian object, packaging it within
+    // a JumpPDF object (a kind of ConditionalPDF object).
+    Gaussian gauss_tmp(1, "");
+    SetFunction(&gauss_tmp);
+}
+
+GaussianConvolution::GaussianConvolution(const std::string &name_, double cutoff_) :
+Convolution(name_), sigma_name("stddevs_0")
+{
+    // Set the kernel to be a Gaussian.
+    // SetFunction() clones this Gaussian object, packaging it within
+    // a JumpPDF object (a kind of ConditionalPDF object).
+    Gaussian gauss_tmp(1, "");
+    gauss_tmp.SetCdfCutOff(cutoff_); // set a custom CDF cutoff
+    SetFunction(&gauss_tmp);
+}
+
+void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int> &column_indices, std::vector<long long unsigned int> &row_indices,
+                                     std::vector<double> &vals) const
+{
+    /*
+     * Construct the sub-matrix associated with the convolution in the transformed axes.
+     * Returns this information, by reference, in the form of column & row indices for non-zero entries of this submatrix,
+     * and their associated values. This form is what Armadillo prefers for sparse matrices!
+     */
+    // variables storing the axes bin information
+    std::vector<double> binCentres(fSubMapAxes.GetNDimensions());
+    std::vector<double> lowEdges(fSubMapAxes.GetNDimensions());
+    std::vector<double> highEdges(fSubMapAxes.GetNDimensions());
+    // Pre-allocate memory for the sub-matrix data
+    // likely to need only a fraction of this memory!
+    column_indices.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
+    row_indices.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
+    vals.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
+    
+    // Some tricks we are pulling here to make things go even faster:
+    // - In most use cases, the binning along the smearing axis is ~equal,
+    //   so the amount of smearing will become translation-invariant!
+    //   Cache calculations of the smearing Integral() (which is expensive)
+    //   in a map object based on the integration endpoints (the output bin edges)
+    //   After the first row, we expect ~all integrals to have already been calculated!
+    // - For typical smearing kernels, the contribution necessarily goes monotonically down
+    //   for bins further away from the original bin. In other words, we expect this submatrix
+    //   to be quite diagonal-heavy, with no random spikes far away.
+    //   Also, beyond some distance we expect the contribution to go to zero.
+    //   Instead of blithely scanning as usual over the full 2D grid of (origBin, destBin),
+    //   we now start ~along the diagonal and work outwards - first forwards, then backwards.
+    //   Whenever a zero is reached, we immediately exit the loop! 
+    std::map<std::pair<double, double>, double> integral_cache;
+    // Loop over all entries of the sub-matrix to determine their values
+    for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
+    {
+        // get the centre of the bin. Need to offset by this for a convolution
+        fSubMapAxes.GetBinCentres(origBin, binCentres);
+
+        // loop over the bins it can be smeared into, going forwards
+        // from the bin after the diagonal first 
+        for (long long unsigned int destBin = origBin+1; destBin < fSubMapAxes.GetNBins(); destBin++)
+        {
+            fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
+            fSubMapAxes.GetBinHighEdges(destBin, highEdges);
+
+            // Calculate destination bin edges along smearing axis, relative
+            // to origBin's centre
+            const double xlo = lowEdges.at(0) - binCentres.at(0);
+            const double xhi = lowEdges.at(0) - binCentres.at(0);
+            const std::pair<double, double> edges {xlo, xhi};
+            // Has an integral already been calculated for this pair of (relative) bin edges?
+            const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
+            double integral = 0.;
+            if (it == integral_cache.end())
+            {
+                // Nope, need to calculate the integral (and add it to the cache)
+                integral = fDist->Integral(lowEdges, highEdges, binCentres);
+                integral_cache[edges] = integral;
+            } else
+            {
+                // Yep, use that result!
+                integral = it->second;
+            }
+
+            // Only bother adding to matrix if non-zero!
+            // No point looking at any further destination bins in this loop
+            // as we know they'll be zero too
+            if (integral == 0.)
+            {
+                break;
+            }
+            column_indices.push_back(origBin);
+            row_indices.push_back(destBin);
+            vals.push_back(integral);
+        }
+        // Now do the same inner loop, but going backwards, starting from
+        // the diagonal - this ensures we don't accidentally try negative bins initially
+        for (long long unsigned int destBin = origBin; destBin < fSubMapAxes.GetNBins(); destBin--)
+        {
+            fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
+            fSubMapAxes.GetBinHighEdges(destBin, highEdges);
+
+            const double xlo = lowEdges.at(0) - binCentres.at(0);
+            const double xhi = lowEdges.at(0) - binCentres.at(0);
+            const std::pair<double, double> edges {xlo, xhi};
+            const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
+            double integral = 0.;
+            if (it == integral_cache.end())
+            {
+                integral = fDist->Integral(lowEdges, highEdges, binCentres);
+                integral_cache[edges] = integral;
+            } else
+            {
+                integral = it->second;
+            }
+
+            if (integral == 0.)
+            {
+                break;
+            }
+            column_indices.push_back(origBin);
+            row_indices.push_back(destBin);
+            vals.push_back(integral);
+        }
+    }
+}
+
+double GaussianConvolution::GetSigma() const
+{
+    return fDist->GetParameter(sigma_name);
+}
+
+void GaussianConvolution::SetSigma(double sigma_)
+{
+    fDist->SetParameter(sigma_name, sigma_);
+}
+
+std::string GaussianConvolution::GetSigmaName() const
+{
+    return sigma_name;
+}
+
+void GaussianConvolution::RenameSigma(const std::string& newname_)
+{
+    fDist->RenameParameter(sigma_name, newname_);
+    sigma_name = newname_;
+}

--- a/src/systematic/GaussianConvolution.cpp
+++ b/src/systematic/GaussianConvolution.cpp
@@ -10,6 +10,7 @@ Convolution(name_), sigma_name("stddevs_0")
     // SetFunction() clones this Gaussian object, packaging it within
     // a JumpPDF object (a kind of ConditionalPDF object).
     Gaussian gauss_tmp(1, "");
+    gauss_tmp.HideMeanParameters(); // we don't want kernel's mean to be a fit parameter
     SetFunction(&gauss_tmp);
 }
 
@@ -21,6 +22,7 @@ Convolution(name_), sigma_name("stddevs_0")
     // a JumpPDF object (a kind of ConditionalPDF object).
     Gaussian gauss_tmp(1, "");
     gauss_tmp.SetCdfCutOff(cutoff_); // set a custom CDF cutoff
+    gauss_tmp.HideMeanParameters(); // we don't want kernel's mean to be a fit parameter
     SetFunction(&gauss_tmp);
 }
 

--- a/src/systematic/GaussianConvolution.cpp
+++ b/src/systematic/GaussianConvolution.cpp
@@ -48,10 +48,7 @@ void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int>
     // - In most use cases, the binning along the smearing axis is ~equal,
     //   so the amount of smearing will become translation-invariant!
     //   Cache calculations of the smearing Integral() (which is expensive)
-    //   in a map object based on the integration upper endpoint (the output upper bin edge).
-    //   We're always calculating the integral relative to the bin centre,
-    //   so the upper and lower endpoints will be symmetric. We can therefore index
-    //   simply by the upper (relative) endpoint, say.
+    //   in a map object based on the integration endpoints (the output bin edges).
     //   After the first row, we expect ~all integrals to have already been calculated!
     // - For typical smearing kernels, the contribution necessarily goes monotonically down
     //   for bins further away from the original bin. In other words, we expect this submatrix
@@ -60,7 +57,7 @@ void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int>
     //   Instead of blithely scanning as usual over the full 2D grid of (origBin, destBin),
     //   we now start ~along the diagonal and work outwards - first forwards, then backwards.
     //   Whenever a zero is reached, we immediately exit the loop! 
-    std::map<double, double> integral_cache;
+    std::map<std::pair<double,double>, double> integral_cache;
     // Loop over all entries of the sub-matrix to determine their values
     for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
     {
@@ -74,17 +71,19 @@ void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int>
             fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
             fSubMapAxes.GetBinHighEdges(destBin, highEdges);
 
-            // Calculate destination upper bin edge along smearing axis, relative
+            // Calculate destination bin edges along smearing axis, relative
             // to origBin's centre
+            const double xlo = lowEdges.at(0) - binCentres.at(0);
             const double xhi = highEdges.at(0) - binCentres.at(0);
+            const std::pair<double, double> edges {xlo, xhi};
             // Has an integral already been calculated for this relative bin edge?
-            const auto it = integral_cache.find(xhi);
+            const auto it = integral_cache.find(edges);
             double integral = 0.;
             if (it == integral_cache.end())
             {
                 // Nope, need to calculate the integral (and add it to the cache)
                 integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                integral_cache[xhi] = integral;
+                integral_cache[edges] = integral;
             } else
             {
                 // Yep, use that result!
@@ -109,13 +108,15 @@ void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int>
             fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
             fSubMapAxes.GetBinHighEdges(destBin, highEdges);
 
-            const double xhi = lowEdges.at(0) - binCentres.at(0);
-            const auto it = integral_cache.find(xhi);
+            const double xlo = lowEdges.at(0) - binCentres.at(0);
+            const double xhi = highEdges.at(0) - binCentres.at(0);
+            const std::pair<double, double> edges {xlo, xhi};
+            const auto it = integral_cache.find(edges);
             double integral = 0.;
             if (it == integral_cache.end())
             {
                 integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                integral_cache[xhi] = integral;
+                integral_cache[edges] = integral;
             } else
             {
                 integral = it->second;

--- a/src/systematic/GaussianConvolution.h
+++ b/src/systematic/GaussianConvolution.h
@@ -27,7 +27,7 @@ public:
     void RenameSigma(const std::string& newname_);
 
 private:
-    std::string sigma_name; // tracks name of Gaussian's sigma parameter: used internally so user doens't need to remember!
+    std::string fSigmaName; // tracks name of Gaussian's sigma parameter: used internally so user doesn't need to remember!
 
     void ConstructSubmatrix(std::vector<long long unsigned int> &column_indices, std::vector<long long unsigned int> &row_indices,
                             std::vector<double> &vals) const;

--- a/src/systematic/GaussianConvolution.h
+++ b/src/systematic/GaussianConvolution.h
@@ -1,0 +1,37 @@
+/*******************************************************/
+/* A specialisation of the Convolution class, for the  */
+/* specific case of a Gaussian kernel.                 */
+/*******************************************************/
+
+#ifndef __OXSX_GAUSSIANCONVOLUTION__
+#define __OXSX_GAUSSIANCONVOLUTION__
+#include <Convolution.h>
+
+
+class GaussianConvolution : public Convolution
+{
+public:
+    // Overwrite the allowed constructor
+    GaussianConvolution(const std::string &name);
+    // Alternative contructor, if you want a custom CDF cutoff:
+    // the number of sigmas away from the mean beyond which the CDF is set to 0 or 1 as appropriate. 5 by default.
+    GaussianConvolution(const std::string &name, double cutoff_);
+    // Getters/Setters for underlying Gaussian distribution's width
+    // (FitComponent interface will still work, this is just a quality-of-life feature)
+    double GetSigma() const;
+    void SetSigma(double sigma_);
+    // Get the Gaussian kernel's sigma parameter's name
+    std::string GetSigmaName() const;
+    // Rename the Gaussian kernel's sigma parameter's name
+    // (default: stddevs_0)
+    void RenameSigma(const std::string& newname_);
+
+private:
+    std::string sigma_name; // tracks name of Gaussian's sigma parameter: used internally so user doens't need to remember!
+
+    void ConstructSubmatrix(std::vector<long long unsigned int> &column_indices, std::vector<long long unsigned int> &row_indices,
+                            std::vector<double> &vals) const;
+};
+
+
+#endif

--- a/src/systematic/GaussianSqrtConvolution.cpp
+++ b/src/systematic/GaussianSqrtConvolution.cpp
@@ -1,32 +1,45 @@
-#include <GaussianConvolution.h>
+#include <GaussianSqrtConvolution.h>
 #include <JumpPDF.h>
 #include <ConditionalPDF.h>
 #include <Gaussian.h>
+#include <VaryingCDF.h>
+#include <SquareRootScale.h>
 
-GaussianConvolution::GaussianConvolution(const std::string &name_) :
-Convolution(name_), fSigmaName("stddevs_0")
+GaussianSqrtConvolution::GaussianSqrtConvolution(const std::string &name_) :
+Convolution(name_), fSigmaName("grad")
 {
-    // Set the kernel to be a Gaussian.
-    // SetFunction() clones this Gaussian object, packaging it within
-    // a JumpPDF object (a kind of ConditionalPDF object).
+    // Set the kernel to be a Gaussian, with square-root scaling
+    // Gaussian* gauss_tmp = new Gaussian(1, "");
     Gaussian gauss_tmp(1, "");
-    gauss_tmp.HideMeanParameters(); // we don't want kernel's mean to be a fit parameter
-    SetFunction(&gauss_tmp);
+
+    VaryingCDF* smearer = new VaryingCDF("");
+    // VaryingCDF smearer("");
+    smearer->SetKernel(&gauss_tmp);
+
+    SquareRootScale* sqrt_scaler = new SquareRootScale("sqrt_scale");
+    smearer->SetDependance("stddevs_0", sqrt_scaler);
+
+    SetConditionalPDF(smearer);
 }
 
-GaussianConvolution::GaussianConvolution(const std::string &name_, double cutoff_) :
-Convolution(name_), fSigmaName("stddevs_0")
+GaussianSqrtConvolution::GaussianSqrtConvolution(const std::string &name_, double cutoff_) :
+Convolution(name_), fSigmaName("grad")
 {
     // Set the kernel to be a Gaussian.
-    // SetFunction() clones this Gaussian object, packaging it within
-    // a JumpPDF object (a kind of ConditionalPDF object).
     Gaussian gauss_tmp(1, "");
     gauss_tmp.SetCdfCutOff(cutoff_); // set a custom CDF cutoff
-    gauss_tmp.HideMeanParameters(); // we don't want kernel's mean to be a fit parameter
-    SetFunction(&gauss_tmp);
+    
+    VaryingCDF* smearer = new VaryingCDF("");
+    // VaryingCDF smearer("");
+    smearer->SetKernel(&gauss_tmp);
+
+    SquareRootScale* fSqrtScaler = new SquareRootScale("sqrt_scale");
+    smearer->SetDependance("stddevs_0", fSqrtScaler);
+
+    SetConditionalPDF(smearer);
 }
 
-void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int> &column_indices, std::vector<long long unsigned int> &row_indices,
+void GaussianSqrtConvolution::ConstructSubmatrix(std::vector<long long unsigned int> &column_indices, std::vector<long long unsigned int> &row_indices,
                                      std::vector<double> &vals) const
 {
     /*
@@ -133,22 +146,22 @@ void GaussianConvolution::ConstructSubmatrix(std::vector<long long unsigned int>
     }
 }
 
-double GaussianConvolution::GetSigma() const
+double GaussianSqrtConvolution::GetSigma() const
 {
     return fDist->GetParameter(fSigmaName);
 }
 
-void GaussianConvolution::SetSigma(double sigma_)
+void GaussianSqrtConvolution::SetSigma(double sigma_)
 {
     fDist->SetParameter(fSigmaName, sigma_);
 }
 
-std::string GaussianConvolution::GetSigmaName() const
+std::string GaussianSqrtConvolution::GetSigmaName() const
 {
     return fSigmaName;
 }
 
-void GaussianConvolution::RenameSigma(const std::string& newname_)
+void GaussianSqrtConvolution::RenameSigma(const std::string& newname_)
 {
     fDist->RenameParameter(fSigmaName, newname_);
     fSigmaName = newname_;

--- a/src/systematic/GaussianSqrtConvolution.cpp
+++ b/src/systematic/GaussianSqrtConvolution.cpp
@@ -9,11 +9,9 @@ GaussianSqrtConvolution::GaussianSqrtConvolution(const std::string &name_) :
 Convolution(name_), fSigmaName("grad")
 {
     // Set the kernel to be a Gaussian, with square-root scaling
-    // Gaussian* gauss_tmp = new Gaussian(1, "");
     Gaussian gauss_tmp(1, "");
 
     VaryingCDF* smearer = new VaryingCDF("");
-    // VaryingCDF smearer("");
     smearer->SetKernel(&gauss_tmp);
 
     SquareRootScale* sqrt_scaler = new SquareRootScale("sqrt_scale");
@@ -30,7 +28,6 @@ Convolution(name_), fSigmaName("grad")
     gauss_tmp.SetCdfCutOff(cutoff_); // set a custom CDF cutoff
     
     VaryingCDF* smearer = new VaryingCDF("");
-    // VaryingCDF smearer("");
     smearer->SetKernel(&gauss_tmp);
 
     SquareRootScale* fSqrtScaler = new SquareRootScale("sqrt_scale");
@@ -58,11 +55,9 @@ void GaussianSqrtConvolution::ConstructSubmatrix(std::vector<long long unsigned 
     vals.reserve(fSubMapAxes.GetNBins() * fSubMapAxes.GetNBins());
     
     // Some tricks we are pulling here to make things go even faster:
-    // - In most use cases, the binning along the smearing axis is ~equal,
-    //   so the amount of smearing will become translation-invariant!
-    //   Cache calculations of the smearing Integral() (which is expensive)
-    //   in a map object based on the integration endpoints (the output bin edges)
-    //   After the first row, we expect ~all integrals to have already been calculated!
+    // - Cache calculations of the smearing Integral() (which is expensive)
+    //   in a map object based on the integration endpoints (the output bin edges),
+    //   scaled by the smearing width.
     // - For typical smearing kernels, the contribution necessarily goes monotonically down
     //   for bins further away from the original bin. In other words, we expect this submatrix
     //   to be quite diagonal-heavy, with no random spikes far away.
@@ -70,7 +65,7 @@ void GaussianSqrtConvolution::ConstructSubmatrix(std::vector<long long unsigned 
     //   Instead of blithely scanning as usual over the full 2D grid of (origBin, destBin),
     //   we now start ~along the diagonal and work outwards - first forwards, then backwards.
     //   Whenever a zero is reached, we immediately exit the loop! 
-    std::map<std::pair<double, double>, double> integral_cache;
+    std::map<double, double> integral_cache;
     // Loop over all entries of the sub-matrix to determine their values
     for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
     {
@@ -84,19 +79,19 @@ void GaussianSqrtConvolution::ConstructSubmatrix(std::vector<long long unsigned 
             fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
             fSubMapAxes.GetBinHighEdges(destBin, highEdges);
 
-            // Calculate destination bin edges along smearing axis, relative
+            // Calculate destination upper bin edge along smearing axis, relative
             // to origBin's centre
-            const double xlo = lowEdges.at(0) - binCentres.at(0);
-            const double xhi = lowEdges.at(0) - binCentres.at(0);
-            const std::pair<double, double> edges {xlo, xhi};
+            const double xhi = highEdges.at(0) - binCentres.at(0);
+            const double width = GetSigma()*sqrt(abs(binCentres.at(0)));
+            const double z = xhi / width;
             // Has an integral already been calculated for this pair of (relative) bin edges?
-            const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
+            const auto it = integral_cache.find(z);
             double integral = 0.;
             if (it == integral_cache.end())
             {
                 // Nope, need to calculate the integral (and add it to the cache)
                 integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                integral_cache[edges] = integral;
+                integral_cache[z] = integral;
             } else
             {
                 // Yep, use that result!
@@ -121,15 +116,15 @@ void GaussianSqrtConvolution::ConstructSubmatrix(std::vector<long long unsigned 
             fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
             fSubMapAxes.GetBinHighEdges(destBin, highEdges);
 
-            const double xlo = lowEdges.at(0) - binCentres.at(0);
             const double xhi = lowEdges.at(0) - binCentres.at(0);
-            const std::pair<double, double> edges {xlo, xhi};
-            const auto it = std::find_if(integral_cache.begin(), integral_cache.end(), [edges](const std::pair<const std::pair<double, double>, double>& p){ return p.first == edges; });
+            const double width = GetSigma()*sqrt(abs(binCentres.at(0)));
+            const double z = xhi / width;
+            const auto it = integral_cache.find(z);
             double integral = 0.;
             if (it == integral_cache.end())
             {
                 integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                integral_cache[edges] = integral;
+                integral_cache[z] = integral;
             } else
             {
                 integral = it->second;

--- a/src/systematic/GaussianSqrtConvolution.cpp
+++ b/src/systematic/GaussianSqrtConvolution.cpp
@@ -65,13 +65,13 @@ void GaussianSqrtConvolution::ConstructSubmatrix(std::vector<long long unsigned 
     //   Instead of blithely scanning as usual over the full 2D grid of (origBin, destBin),
     //   we now start ~along the diagonal and work outwards - first forwards, then backwards.
     //   Whenever a zero is reached, we immediately exit the loop! 
-    std::map<double, double> integral_cache;
+    std::map<std::pair<double,double>, double> integral_cache;
     // Loop over all entries of the sub-matrix to determine their values
     for (long long unsigned int origBin = 0; origBin < fSubMapAxes.GetNBins(); origBin++)
     {
         // get the centre of the bin. Need to offset by this for a convolution
         fSubMapAxes.GetBinCentres(origBin, binCentres);
-
+        const double width = GetSigma()*sqrt(abs(binCentres.at(0))); // width of kernel
         // loop over the bins it can be smeared into, going forwards
         // from the bin after the diagonal first 
         for (long long unsigned int destBin = origBin+1; destBin < fSubMapAxes.GetNBins(); destBin++)
@@ -80,18 +80,20 @@ void GaussianSqrtConvolution::ConstructSubmatrix(std::vector<long long unsigned 
             fSubMapAxes.GetBinHighEdges(destBin, highEdges);
 
             // Calculate destination upper bin edge along smearing axis, relative
-            // to origBin's centre
+            // to origBin's centre and kernel's width
+            const double xlo = lowEdges.at(0) - binCentres.at(0);
             const double xhi = highEdges.at(0) - binCentres.at(0);
-            const double width = GetSigma()*sqrt(abs(binCentres.at(0)));
-            const double z = xhi / width;
+            const double zlo = xlo / width;
+            const double zhi = xhi / width;
+            const std::pair<double, double> zs {zlo, zhi};
             // Has an integral already been calculated for this pair of (relative) bin edges?
-            const auto it = integral_cache.find(z);
+            const auto it = integral_cache.find(zs);
             double integral = 0.;
             if (it == integral_cache.end())
             {
                 // Nope, need to calculate the integral (and add it to the cache)
                 integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                integral_cache[z] = integral;
+                integral_cache[zs] = integral;
             } else
             {
                 // Yep, use that result!
@@ -116,15 +118,17 @@ void GaussianSqrtConvolution::ConstructSubmatrix(std::vector<long long unsigned 
             fSubMapAxes.GetBinLowEdges(destBin, lowEdges);
             fSubMapAxes.GetBinHighEdges(destBin, highEdges);
 
-            const double xhi = lowEdges.at(0) - binCentres.at(0);
-            const double width = GetSigma()*sqrt(abs(binCentres.at(0)));
-            const double z = xhi / width;
-            const auto it = integral_cache.find(z);
+            const double xlo = lowEdges.at(0) - binCentres.at(0);
+            const double xhi = highEdges.at(0) - binCentres.at(0);
+            const double zlo = xlo / width;
+            const double zhi = xhi / width;
+            const std::pair<double, double> zs {zlo, zhi};
+            const auto it = integral_cache.find(zs);
             double integral = 0.;
             if (it == integral_cache.end())
             {
                 integral = fDist->Integral(lowEdges, highEdges, binCentres);
-                integral_cache[z] = integral;
+                integral_cache[zs] = integral;
             } else
             {
                 integral = it->second;

--- a/src/systematic/GaussianSqrtConvolution.h
+++ b/src/systematic/GaussianSqrtConvolution.h
@@ -18,8 +18,6 @@ public:
     // Alternative contructor, if you want a custom CDF cutoff:
     // the number of sigmas away from the mean beyond which the CDF is set to 0 or 1 as appropriate. 5 by default.
     GaussianSqrtConvolution(const std::string &name, double cutoff_);
-    // Destructor
-    // ~GaussianSqrtConvolution();
     // Getters/Setters for underlying SquareRootScale's width parameter -
     // this is the proportionality constant which multiplies the sqrt scaling
     // (FitComponent interface will still work, this is just a quality-of-life feature)

--- a/src/systematic/GaussianSqrtConvolution.h
+++ b/src/systematic/GaussianSqrtConvolution.h
@@ -1,0 +1,42 @@
+/****************************************************************/
+/* A specialisation of the Convolution class, for the           */
+/* specific case of a Gaussian kernel with a width that         */
+/* varies proportional to the square root of the smearing axis. */
+/* Useful in particular for smearing along in energy, say.      */
+/****************************************************************/
+
+#ifndef __OXSX_GAUSSIANSQRTCONVOLUTION__
+#define __OXSX_GAUSSIANSQRTCONVOLUTION__
+#include <Convolution.h>
+
+
+class GaussianSqrtConvolution : public Convolution
+{
+public:
+    // Overwrite the allowed constructor
+    GaussianSqrtConvolution(const std::string &name);
+    // Alternative contructor, if you want a custom CDF cutoff:
+    // the number of sigmas away from the mean beyond which the CDF is set to 0 or 1 as appropriate. 5 by default.
+    GaussianSqrtConvolution(const std::string &name, double cutoff_);
+    // Destructor
+    // ~GaussianSqrtConvolution();
+    // Getters/Setters for underlying SquareRootScale's width parameter -
+    // this is the proportionality constant which multiplies the sqrt scaling
+    // (FitComponent interface will still work, this is just a quality-of-life feature)
+    double GetSigma() const;
+    void SetSigma(double sigma_);
+    // Get the kernel's width parameter's name
+    std::string GetSigmaName() const;
+    // Rename the kernel's width parameter's name
+    // (default: "grad")
+    void RenameSigma(const std::string& newname_);
+
+private:
+    std::string fSigmaName; // tracks name of kernel's width parameter: used internally so user doesn't need to remember!
+
+    void ConstructSubmatrix(std::vector<long long unsigned int> &column_indices, std::vector<long long unsigned int> &row_indices,
+                            std::vector<double> &vals) const;
+};
+
+
+#endif

--- a/src/systematic/Scale.cpp
+++ b/src/systematic/Scale.cpp
@@ -28,6 +28,7 @@ void Scale::Construct()
     const BinAxis &scaleAxis = fAxes.GetAxis(fDistObs.GetIndex(scaleAxisName));
     // Each (pre-scaled) bin gets a mapping from (post-scaled) bins to non-zero values
     std::vector<std::map<size_t, double>> scale_vals(scaleAxis.GetNBins(), std::map<size_t, double>{});
+    size_t nvals = 0;
     for (size_t bin = 0; bin < scaleAxis.GetNBins(); bin++)
     {
         // First - work out edges of scaled bin interval along axis
@@ -43,22 +44,42 @@ void Scale::Construct()
             if (contribution > 0)
             {
                 scale_vals[bin][bin_test] = contribution;
+                nvals++;
             }
         }
     }
 
-    // Finally, construct the full response matrix by setting the diagonal
+    // Finally, construct the full response matrix by setting the non-zero
     // elements to their appropriate value, using the bin ID mapping to help.
     fResponse.SetZeros();
+    // Set up variables first; pre-allocate memory for the large vectors associated with the full matrix's info
+    const size_t N = fAxes.GetNBins();
+    const size_t n_sub = scaleAxis.GetNBins();
+    const size_t n_blocks = N / n_sub;
+    const size_t size_block = nvals;
+    std::vector<long long unsigned int> column_indices_bl;
+    std::vector<long long unsigned int> row_indices_bl;
+    std::vector<double> vals_bl;
+    column_indices_bl.reserve(size_block * n_blocks);
+    row_indices_bl.reserve(size_block * n_blocks);
+    vals_bl.reserve(size_block * n_blocks);
+    // Loop over all origin bins
     for (size_t obs_bin_id = 0; obs_bin_id < fAxes.GetNBins(); obs_bin_id++)
     {
+        // ...and also loop over all possible non-zero destination bins
         const size_t scaleAxisBin = fDistTransBinMapping.at(obs_bin_id);
         for (const auto &postScaleBinPair : scale_vals.at(scaleAxisBin))
         {
+            // Put info about contribution for this bin into relevant vectors
             const size_t scaled_bin_id = fMappingDistAndTrans.GetComponent(obs_bin_id, postScaleBinPair.first);
-            fResponse.SetComponent(scaled_bin_id, obs_bin_id, postScaleBinPair.second);
+            row_indices_bl.push_back(scaled_bin_id);
+            column_indices_bl.push_back(obs_bin_id);
+            vals_bl.push_back(postScaleBinPair.second);
         }
     }
+    // Set elements of full response matrix all in one go using filled vectors
+    fResponse = SparseMatrix(N, N);
+    fResponse.SetComponents(row_indices_bl, column_indices_bl, vals_bl);
 }
 
 void Scale::SetScaleFactor(double scaleFactor_)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -24,6 +24,7 @@ set(tests
     EventShiftTest.cpp
     EventSystematicManagerTest.cpp
     FitParameterTest.cpp
+    GaussianConvolutionTest.cpp
     GaussianFitterTest.cpp
     GaussianTest.cpp
     HistogramGetMultiDSlice.cpp

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -25,6 +25,7 @@ set(tests
     EventSystematicManagerTest.cpp
     FitParameterTest.cpp
     GaussianConvolutionTest.cpp
+    GaussianSqrtConvolutionTest.cpp
     GaussianFitterTest.cpp
     GaussianTest.cpp
     HistogramGetMultiDSlice.cpp

--- a/test/unit/GaussianConvolutionTest.cpp
+++ b/test/unit/GaussianConvolutionTest.cpp
@@ -270,3 +270,71 @@ TEST_CASE("Simple GaussianConvolution systematic on 2d PDF, alt axis ordering")
     REQUIRE(modifiedObs == correctVals);
   }
 }
+
+TEST_CASE("GaussianConvolution systematic on 1d PDF, variable binning")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  const std::vector<double> lowEdges {0., 1., 3., 4.};
+  const std::vector<double> highEdges {1., 3., 4., 4.5};
+  axes.AddAxis(BinAxis("axis0", lowEdges, highEdges));
+  std::vector<std::string> observables;
+  observables.push_back("obs0");
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(1, 10);
+  pdf1.SetObservables(observables);
+
+  // Now build the GaussianConvolution systematic
+  double sigma = 0.5;
+
+  GaussianConvolution conv("smear_sys");
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(observables);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check GetSigmaName() method")
+  {
+    REQUIRE(conv.GetSigmaName() == "sigma");
+  }
+
+  SECTION("Check FitComponent interface for GaussianConvolution, 1D")
+  {
+    REQUIRE(conv.GetParameterCount() == 1); // one param: Gaussian's sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 1.;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 1D GaussianConvolution smearing")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu = 2.0; // centre of bin which has data in it
+
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals = {
+        10. * (gsl_cdf_gaussian_P(1 - mu, sigma) - gsl_cdf_gaussian_P(0 - mu, sigma)),
+        10. * (gsl_cdf_gaussian_P(3 - mu, sigma) - gsl_cdf_gaussian_P(1 - mu, sigma)),
+        10. * (gsl_cdf_gaussian_P(4 - mu, sigma) - gsl_cdf_gaussian_P(3 - mu, sigma)),
+        10. * (gsl_cdf_gaussian_P(4.5 - mu, sigma) - gsl_cdf_gaussian_P(4 - mu, sigma)),
+    };
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}

--- a/test/unit/GaussianConvolutionTest.cpp
+++ b/test/unit/GaussianConvolutionTest.cpp
@@ -33,7 +33,7 @@ TEST_CASE("Simple GaussianConvolution systematic on 1d PDF")
 
   SECTION("Check FitComponent interface for GaussianConvolution, 1D")
   {
-    REQUIRE(conv.GetParameterCount() == 2); // two params: Gaussian's mean and sigma
+    REQUIRE(conv.GetParameterCount() == 1); // one param: Gaussian's sigma
     REQUIRE(conv.GetParameter("sigma") == sigma);
     REQUIRE(conv.GetName() == "smear_sys");
 
@@ -99,7 +99,7 @@ TEST_CASE("Simple GaussianConvolution systematic on 1d PDF, small CDF cutoff")
 
   SECTION("Check FitComponent interface for GaussianConvolution, 1D, with custom cutoff in place")
   {
-    REQUIRE(conv.GetParameterCount() == 2); // two params: Gaussian's mean and sigma
+    REQUIRE(conv.GetParameterCount() == 1); // one param: Gaussian's sigma
     REQUIRE(conv.GetParameter("sigma") == sigma);
     REQUIRE(conv.GetName() == "smear_sys");
 
@@ -163,7 +163,7 @@ TEST_CASE("Simple GaussianConvolution systematic on 2d PDF")
 
   SECTION("Check FitComponent interface for GaussianConvolution, 2D")
   {
-    REQUIRE(conv.GetParameterCount() == 2); // two params: Gaussian's mean and sigma
+    REQUIRE(conv.GetParameterCount() == 1); // one param: Gaussian's sigma
     REQUIRE(conv.GetParameter("sigma") == sigma);
     REQUIRE(conv.GetName() == "smear_sys");
 
@@ -230,7 +230,7 @@ TEST_CASE("Simple GaussianConvolution systematic on 2d PDF, alt axis ordering")
 
   SECTION("Check FitComponent interface for GaussianConvolution, 2D")
   {
-    REQUIRE(conv.GetParameterCount() == 2); // two params: Gaussian's mean and sigma
+    REQUIRE(conv.GetParameterCount() == 1); // one params: Gaussian's sigma
     REQUIRE(conv.GetParameter("sigma") == sigma);
     REQUIRE(conv.GetName() == "smear_sys");
 

--- a/test/unit/GaussianConvolutionTest.cpp
+++ b/test/unit/GaussianConvolutionTest.cpp
@@ -1,0 +1,272 @@
+#include <catch2/catch_all.hpp>
+#include <SystematicManager.h>
+#include <GaussianConvolution.h>
+#include <JumpPDF.h>
+#include <gsl/gsl_cdf.h>
+
+TEST_CASE("Simple GaussianConvolution systematic on 1d PDF")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  axes.AddAxis(BinAxis("axis0", 0, 4, 4));
+  std::vector<std::string> observables;
+  observables.push_back("obs0");
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(1, 10);
+  pdf1.SetObservables(observables);
+
+  // Now build the GaussianConvolution systematic
+  double sigma = 0.5;
+
+  GaussianConvolution conv("smear_sys");
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(observables);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check GetSigmaName() method")
+  {
+    REQUIRE(conv.GetSigmaName() == "sigma");
+  }
+
+  SECTION("Check FitComponent interface for GaussianConvolution, 1D")
+  {
+    REQUIRE(conv.GetParameterCount() == 2); // two params: Gaussian's mean and sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 0.4;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 1D GaussianConvolution smearing")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu = 1.5; // centre of bin which has data in it
+
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals = {
+        10. * (gsl_cdf_gaussian_P(1 - mu, sigma) - gsl_cdf_gaussian_P(0 - mu, sigma)),
+        10. * (gsl_cdf_gaussian_P(2 - mu, sigma) - gsl_cdf_gaussian_P(1 - mu, sigma)),
+        10. * (gsl_cdf_gaussian_P(3 - mu, sigma) - gsl_cdf_gaussian_P(2 - mu, sigma)),
+        10. * (gsl_cdf_gaussian_P(4 - mu, sigma) - gsl_cdf_gaussian_P(3 - mu, sigma)),
+    };
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}
+
+TEST_CASE("Simple GaussianConvolution systematic on 1d PDF, small CDF cutoff")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  axes.AddAxis(BinAxis("axis0", 0, 4, 4));
+  std::vector<std::string> observables;
+  observables.push_back("obs0");
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(1, 10);
+  pdf1.SetObservables(observables);
+
+  // Now build the GaussianConvolution systematic
+  double sigma = 0.5;
+  const double cdfcutoff = 1.; // comedically small cutoff, just to test 
+  GaussianConvolution conv("smear_sys", cdfcutoff);
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(observables);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check GetSigmaName() method, with custom cutoff in place")
+  {
+    REQUIRE(conv.GetSigmaName() == "sigma");
+  }
+
+  SECTION("Check FitComponent interface for GaussianConvolution, 1D, with custom cutoff in place")
+  {
+    REQUIRE(conv.GetParameterCount() == 2); // two params: Gaussian's mean and sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 0.4;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 1D GaussianConvolution smearing, with custom cutoff in place")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu = 1.5; // centre of bin which has data in it
+
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    // values different now because of the CDF
+    std::vector<double> correctVals = {
+        10. * (gsl_cdf_gaussian_P(1 - mu, sigma) - 0.),
+        10. * (gsl_cdf_gaussian_P(2 - mu, sigma) - gsl_cdf_gaussian_P(1 - mu, sigma)),
+        10. * (1. - gsl_cdf_gaussian_P(2 - mu, sigma)),
+        10. * (0. - 0.),
+    };
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}
+
+TEST_CASE("Simple GaussianConvolution systematic on 2d PDF")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  axes.AddAxis(BinAxis("axis0", 0, 4, 4));
+  axes.AddAxis(BinAxis("axis1", 0, 2, 2));
+  const std::vector<std::string> observables = {"obs0", "obs1"};
+  const std::vector<std::string> obs_smear = {"obs0"};
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(axes.FlattenIndices({1, 0}), 10);
+  pdf1.SetBinContent(axes.FlattenIndices({2, 1}), 20);
+  pdf1.SetObservables(observables);
+
+  // Now build the Convolution systematic and related objects
+  double sigma = 0.5;
+
+  GaussianConvolution conv("smear_sys");
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(obs_smear);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check FitComponent interface for GaussianConvolution, 2D")
+  {
+    REQUIRE(conv.GetParameterCount() == 2); // two params: Gaussian's mean and sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 0.4;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 2D GaussianConvolution smearing")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu1 = 1.5; // centres of bins which has data in it
+    const double mu2 = 2.5; // centres of bins which has data in it
+
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals(pdf1.GetNBins(), 0);
+    correctVals[axes.FlattenIndices({0, 0})] = 10. * (gsl_cdf_gaussian_P(1 - mu1, sigma) - gsl_cdf_gaussian_P(0 - mu1, sigma));
+    correctVals[axes.FlattenIndices({1, 0})] = 10. * (gsl_cdf_gaussian_P(2 - mu1, sigma) - gsl_cdf_gaussian_P(1 - mu1, sigma));
+    correctVals[axes.FlattenIndices({2, 0})] = 10. * (gsl_cdf_gaussian_P(3 - mu1, sigma) - gsl_cdf_gaussian_P(2 - mu1, sigma));
+    correctVals[axes.FlattenIndices({3, 0})] = 10. * (gsl_cdf_gaussian_P(4 - mu1, sigma) - gsl_cdf_gaussian_P(3 - mu1, sigma));
+    correctVals[axes.FlattenIndices({0, 1})] = 20. * (gsl_cdf_gaussian_P(1 - mu2, sigma) - gsl_cdf_gaussian_P(0 - mu2, sigma));
+    correctVals[axes.FlattenIndices({1, 1})] = 20. * (gsl_cdf_gaussian_P(2 - mu2, sigma) - gsl_cdf_gaussian_P(1 - mu2, sigma));
+    correctVals[axes.FlattenIndices({2, 1})] = 20. * (gsl_cdf_gaussian_P(3 - mu2, sigma) - gsl_cdf_gaussian_P(2 - mu2, sigma));
+    correctVals[axes.FlattenIndices({3, 1})] = 20. * (gsl_cdf_gaussian_P(4 - mu2, sigma) - gsl_cdf_gaussian_P(3 - mu2, sigma));
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}
+
+TEST_CASE("Simple GaussianConvolution systematic on 2d PDF, alt axis ordering")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  axes.AddAxis(BinAxis("axis1", 0, 2, 2));
+  axes.AddAxis(BinAxis("axis0", 0, 4, 4));
+  const std::vector<std::string> observables = {"obs1", "obs0"};
+  const std::vector<std::string> obs_smear = {"obs0"};
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(axes.FlattenIndices({0, 1}), 10);
+  pdf1.SetBinContent(axes.FlattenIndices({1, 2}), 20);
+  pdf1.SetObservables(observables);
+
+  // Now build the Convolution systematic and related objects
+  double sigma = 0.5;
+
+  GaussianConvolution conv("smear_sys");
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(obs_smear);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check FitComponent interface for GaussianConvolution, 2D")
+  {
+    REQUIRE(conv.GetParameterCount() == 2); // two params: Gaussian's mean and sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 0.4;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 2D GaussianConvolution smearing")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu1 = 1.5; // centres of bins which has data in it
+    const double mu2 = 2.5; // centres of bins which has data in it
+
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals(pdf1.GetNBins(), 0);
+    correctVals[axes.FlattenIndices({0, 0})] = 10. * (gsl_cdf_gaussian_P(1 - mu1, sigma) - gsl_cdf_gaussian_P(0 - mu1, sigma));
+    correctVals[axes.FlattenIndices({0, 1})] = 10. * (gsl_cdf_gaussian_P(2 - mu1, sigma) - gsl_cdf_gaussian_P(1 - mu1, sigma));
+    correctVals[axes.FlattenIndices({0, 2})] = 10. * (gsl_cdf_gaussian_P(3 - mu1, sigma) - gsl_cdf_gaussian_P(2 - mu1, sigma));
+    correctVals[axes.FlattenIndices({0, 3})] = 10. * (gsl_cdf_gaussian_P(4 - mu1, sigma) - gsl_cdf_gaussian_P(3 - mu1, sigma));
+    correctVals[axes.FlattenIndices({1, 0})] = 20. * (gsl_cdf_gaussian_P(1 - mu2, sigma) - gsl_cdf_gaussian_P(0 - mu2, sigma));
+    correctVals[axes.FlattenIndices({1, 1})] = 20. * (gsl_cdf_gaussian_P(2 - mu2, sigma) - gsl_cdf_gaussian_P(1 - mu2, sigma));
+    correctVals[axes.FlattenIndices({1, 2})] = 20. * (gsl_cdf_gaussian_P(3 - mu2, sigma) - gsl_cdf_gaussian_P(2 - mu2, sigma));
+    correctVals[axes.FlattenIndices({1, 3})] = 20. * (gsl_cdf_gaussian_P(4 - mu2, sigma) - gsl_cdf_gaussian_P(3 - mu2, sigma));
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}

--- a/test/unit/GaussianSqrtConvolutionTest.cpp
+++ b/test/unit/GaussianSqrtConvolutionTest.cpp
@@ -1,0 +1,274 @@
+#include <catch2/catch_all.hpp>
+#include <SystematicManager.h>
+#include <GaussianSqrtConvolution.h>
+#include <JumpPDF.h>
+#include <gsl/gsl_cdf.h>
+
+TEST_CASE("Simple GaussianSqrtConvolution systematic on 1d PDF")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  axes.AddAxis(BinAxis("axis0", 0, 4, 4));
+  std::vector<std::string> observables;
+  observables.push_back("obs0");
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(1, 10);
+  pdf1.SetObservables(observables);
+
+  // Now build the GaussianSqrtConvolution systematic
+  double sigma = 0.5;
+
+  GaussianSqrtConvolution conv("smear_sys");
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(observables);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check GetSigmaName() method")
+  {
+    REQUIRE(conv.GetSigmaName() == "sigma");
+  }
+
+  SECTION("Check FitComponent interface for GaussianSqrtConvolution, 1D")
+  {
+    REQUIRE(conv.GetParameterCount() == 1); // one param: Gaussian's sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 0.4;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 1D GaussianSqrtConvolution smearing")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu = 1.5; // centre of bin which has data in it
+    const double s = sigma*std::sqrt(mu);
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals = {
+        10. * (gsl_cdf_gaussian_P(1 - mu, s) - gsl_cdf_gaussian_P(0 - mu, s)),
+        10. * (gsl_cdf_gaussian_P(2 - mu, s) - gsl_cdf_gaussian_P(1 - mu, s)),
+        10. * (gsl_cdf_gaussian_P(3 - mu, s) - gsl_cdf_gaussian_P(2 - mu, s)),
+        10. * (gsl_cdf_gaussian_P(4 - mu, s) - gsl_cdf_gaussian_P(3 - mu, s)),
+    };
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}
+
+TEST_CASE("Simple GaussianSqrtConvolution systematic on 1d PDF, small CDF cutoff")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  axes.AddAxis(BinAxis("axis0", 0, 4, 4));
+  std::vector<std::string> observables;
+  observables.push_back("obs0");
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(1, 10);
+  pdf1.SetObservables(observables);
+
+  // Now build the GaussianSqrtConvolution systematic
+  double sigma = 0.5;
+  const double cdfcutoff = 1.; // comedically small cutoff, just to test 
+  GaussianSqrtConvolution conv("smear_sys", cdfcutoff);
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(observables);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check GetSigmaName() method, with custom cutoff in place")
+  {
+    REQUIRE(conv.GetSigmaName() == "sigma");
+  }
+
+  SECTION("Check FitComponent interface for GaussianSqrtConvolution, 1D, with custom cutoff in place")
+  {
+    REQUIRE(conv.GetParameterCount() == 1); // one param: Gaussian's sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 0.4;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 1D GaussianSqrtConvolution smearing, with custom cutoff in place")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu = 1.5; // centre of bin which has data in it
+    const double s = sigma*std::sqrt(mu);
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    // values different now because of the CDF
+    std::vector<double> correctVals = {
+        10. * (gsl_cdf_gaussian_P(1 - mu, s) - 0.),
+        10. * (gsl_cdf_gaussian_P(2 - mu, s) - gsl_cdf_gaussian_P(1 - mu, s)),
+        10. * (1. - gsl_cdf_gaussian_P(2 - mu, s)),
+        10. * (0. - 0.),
+    };
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}
+
+TEST_CASE("Simple GaussianSqrtConvolution systematic on 2d PDF")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  axes.AddAxis(BinAxis("axis0", 0, 4, 4));
+  axes.AddAxis(BinAxis("axis1", 0, 2, 2));
+  const std::vector<std::string> observables = {"obs0", "obs1"};
+  const std::vector<std::string> obs_smear = {"obs0"};
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(axes.FlattenIndices({1, 0}), 10);
+  pdf1.SetBinContent(axes.FlattenIndices({2, 1}), 20);
+  pdf1.SetObservables(observables);
+
+  // Now build the GaussianSqrtConvolution systematic and related objects
+  double sigma = 0.5;
+
+  GaussianSqrtConvolution conv("smear_sys");
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(obs_smear);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check FitComponent interface for GaussianSqrtConvolution, 2D")
+  {
+    REQUIRE(conv.GetParameterCount() == 1); // one param: Gaussian's sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 0.4;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 2D GaussianSqrtConvolution smearing")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu1 = 1.5; // centres of bins which has data in it
+    const double mu2 = 2.5; // centres of bins which has data in it
+    const double s1 = sigma*std::sqrt(mu1);
+    const double s2 = sigma*std::sqrt(mu2);
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals(pdf1.GetNBins(), 0);
+    correctVals[axes.FlattenIndices({0, 0})] = 10. * (gsl_cdf_gaussian_P(1 - mu1, s1) - gsl_cdf_gaussian_P(0 - mu1, s1));
+    correctVals[axes.FlattenIndices({1, 0})] = 10. * (gsl_cdf_gaussian_P(2 - mu1, s1) - gsl_cdf_gaussian_P(1 - mu1, s1));
+    correctVals[axes.FlattenIndices({2, 0})] = 10. * (gsl_cdf_gaussian_P(3 - mu1, s1) - gsl_cdf_gaussian_P(2 - mu1, s1));
+    correctVals[axes.FlattenIndices({3, 0})] = 10. * (gsl_cdf_gaussian_P(4 - mu1, s1) - gsl_cdf_gaussian_P(3 - mu1, s1));
+    correctVals[axes.FlattenIndices({0, 1})] = 20. * (gsl_cdf_gaussian_P(1 - mu2, s2) - gsl_cdf_gaussian_P(0 - mu2, s2));
+    correctVals[axes.FlattenIndices({1, 1})] = 20. * (gsl_cdf_gaussian_P(2 - mu2, s2) - gsl_cdf_gaussian_P(1 - mu2, s2));
+    correctVals[axes.FlattenIndices({2, 1})] = 20. * (gsl_cdf_gaussian_P(3 - mu2, s2) - gsl_cdf_gaussian_P(2 - mu2, s2));
+    correctVals[axes.FlattenIndices({3, 1})] = 20. * (gsl_cdf_gaussian_P(4 - mu2, s2) - gsl_cdf_gaussian_P(3 - mu2, s2));
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}
+
+TEST_CASE("Simple GaussianSqrtConvolution systematic on 2d PDF, alt axis ordering")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  axes.AddAxis(BinAxis("axis1", 0, 2, 2));
+  axes.AddAxis(BinAxis("axis0", 0, 4, 4));
+  const std::vector<std::string> observables = {"obs1", "obs0"};
+  const std::vector<std::string> obs_smear = {"obs0"};
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(axes.FlattenIndices({0, 1}), 10);
+  pdf1.SetBinContent(axes.FlattenIndices({1, 2}), 20);
+  pdf1.SetObservables(observables);
+
+  // Now build the GaussianSqrtConvolution systematic and related objects
+  double sigma = 0.5;
+
+  GaussianSqrtConvolution conv("smear_sys");
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(obs_smear);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check FitComponent interface for GaussianSqrtConvolution, 2D")
+  {
+    REQUIRE(conv.GetParameterCount() == 1); // one params: Gaussian's sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 0.4;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 2D GaussianSqrtConvolution smearing")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu1 = 1.5; // centres of bins which has data in it
+    const double mu2 = 2.5; // centres of bins which has data in it
+    const double s1 = sigma*std::sqrt(mu1);
+    const double s2 = sigma*std::sqrt(mu2);
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals(pdf1.GetNBins(), 0);
+    correctVals[axes.FlattenIndices({0, 0})] = 10. * (gsl_cdf_gaussian_P(1 - mu1, s1) - gsl_cdf_gaussian_P(0 - mu1, s1));
+    correctVals[axes.FlattenIndices({0, 1})] = 10. * (gsl_cdf_gaussian_P(2 - mu1, s1) - gsl_cdf_gaussian_P(1 - mu1, s1));
+    correctVals[axes.FlattenIndices({0, 2})] = 10. * (gsl_cdf_gaussian_P(3 - mu1, s1) - gsl_cdf_gaussian_P(2 - mu1, s1));
+    correctVals[axes.FlattenIndices({0, 3})] = 10. * (gsl_cdf_gaussian_P(4 - mu1, s1) - gsl_cdf_gaussian_P(3 - mu1, s1));
+    correctVals[axes.FlattenIndices({1, 0})] = 20. * (gsl_cdf_gaussian_P(1 - mu2, s2) - gsl_cdf_gaussian_P(0 - mu2, s2));
+    correctVals[axes.FlattenIndices({1, 1})] = 20. * (gsl_cdf_gaussian_P(2 - mu2, s2) - gsl_cdf_gaussian_P(1 - mu2, s2));
+    correctVals[axes.FlattenIndices({1, 2})] = 20. * (gsl_cdf_gaussian_P(3 - mu2, s2) - gsl_cdf_gaussian_P(2 - mu2, s2));
+    correctVals[axes.FlattenIndices({1, 3})] = 20. * (gsl_cdf_gaussian_P(4 - mu2, s2) - gsl_cdf_gaussian_P(3 - mu2, s2));
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}

--- a/test/unit/GaussianSqrtConvolutionTest.cpp
+++ b/test/unit/GaussianSqrtConvolutionTest.cpp
@@ -272,3 +272,71 @@ TEST_CASE("Simple GaussianSqrtConvolution systematic on 2d PDF, alt axis orderin
     REQUIRE(modifiedObs == correctVals);
   }
 }
+
+TEST_CASE("GaussianSqrtConvolution systematic on 1d PDF, variable binning")
+{
+  // First - build base 1D BinnedED object for applying systematic to
+  AxisCollection axes;
+  const std::vector<double> lowEdges {0., 1., 3., 4.};
+  const std::vector<double> highEdges {1., 3., 4., 4.5};
+  axes.AddAxis(BinAxis("axis0", lowEdges, highEdges));
+  std::vector<std::string> observables;
+  observables.push_back("obs0");
+
+  BinnedED pdf1("pdf1", axes);
+  pdf1.SetBinContent(1, 10);
+  pdf1.SetObservables(observables);
+
+  // Now build the GaussianSqrtConvolution systematic
+  double sigma = 0.5;
+
+  GaussianSqrtConvolution conv("smear_sys");
+  conv.RenameSigma("sigma");
+  conv.SetSigma(sigma);
+  conv.SetAxes(axes);
+  conv.SetTransformationObs(observables);
+  conv.SetDistributionObs(observables);
+
+  SECTION("Check GetSigmaName() method")
+  {
+    REQUIRE(conv.GetSigmaName() == "sigma");
+  }
+
+  SECTION("Check FitComponent interface for GaussianSqrtConvolution, 1D")
+  {
+    REQUIRE(conv.GetParameterCount() == 1); // one param: Gaussian's sigma
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+    REQUIRE(conv.GetName() == "smear_sys");
+
+    sigma = 1.;
+    conv.SetParameter("sigma", sigma);
+    REQUIRE(conv.GetParameter("sigma") == sigma);
+  }
+
+  // Add systematic & BinnedED objects to a systematic manager; test smearing
+  SystematicManager man;
+
+  SECTION("Test 1D GaussianSqrtConvolution smearing")
+  {
+    man.Add(&conv);
+    man.AddDist(pdf1, "");
+    man.Construct();
+
+    std::vector<BinnedED> pdfs = {pdf1};
+    std::vector<BinnedED> OrignalPdfs(pdfs);
+
+    man.DistortEDs(OrignalPdfs, pdfs);
+
+    const double mu = 2.; // centre of bin which has data in it
+    const double s = sigma*std::sqrt(mu);
+    std::vector<double> modifiedObs = pdfs.at(0).GetBinContents();
+    std::vector<double> correctVals = {
+        10. * (gsl_cdf_gaussian_P(1 - mu, s) - gsl_cdf_gaussian_P(0 - mu, s)),
+        10. * (gsl_cdf_gaussian_P(3 - mu, s) - gsl_cdf_gaussian_P(1 - mu, s)),
+        10. * (gsl_cdf_gaussian_P(4 - mu, s) - gsl_cdf_gaussian_P(3 - mu, s)),
+        10. * (gsl_cdf_gaussian_P(4.5 - mu, s) - gsl_cdf_gaussian_P(4 - mu, s)),
+    };
+
+    REQUIRE(modifiedObs == correctVals);
+  }
+}


### PR DESCRIPTION
This PR does a number of things, but its primary aim is the creation of two new "ready-to-use" Systematic classes that have been much asked for: `GaussianConvolution` and `GaussianSqrtConvolution`. These both derive from the underlying `Convolution` class, handling the special case of a 1D Gaussian smearing kernel; the latter also includes a square root scaling dependence to the kernel's width that is often used when smearing along an energy axis.

Because of various special properties that a Gaussian kernel has, the `ConstructSubMatrix()` method was overloaded in both classes to allow for much faster response matrix generation. This was achieved through two main tricks:

1. Because of the translational symmetry of the kernel (particularly in the case of `GaussianConvolution` with constant bin widths) the calculated contributions will often be highly repeated; we now cache results and check to see if they've already been calculated.
2. Beyond a certain distance (by default 5 sigma) the Gaussian kernel outputs a 0 contribution. We know there's no point looking beyond there along that row! So instead of scanning along the rows and columns of the response matrix in the usual way, we instead start along the diagonal and move outwards in both directions, ending a sub-loop once we've hit a zero.

Further updates were made to support these new classes:

- We want the `GaussianConvolution` class to have the `FitComponent` interface accessing the sigma of the Gaussian only, not the mean (which is irrelevant during a smearing convolution). A new option to `HideMeanParameters()` was added within the `Gaussian` and `GaussianFitter` classes to support this.
- The `private` members/methods of the underlying `Convolution` class are updated to being `protected`, so that our new classes can access them.
- Unit tests were written for both new classes.
- The MCMC.cpp example code has been updated to include these new classes as a demonstration.

In addition, an update to the `Scale` systematic's `Construct()` method was made so that one single `SetComponents()` call was made instead of many individual `SetComponent()` calls. This should hopefully make `Scale` that bit faster too.